### PR TITLE
chore(deps): bump eslint-plugin-simple-import-sort 12 → 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-prettier": "5.5.6",
-    "eslint-plugin-simple-import-sort": "12.1.1",
+    "eslint-plugin-simple-import-sort": "13.0.0",
     "globals": "17.7.0",
     "graceful-fs": "4.2.11",
     "husky": "9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ importers:
         specifier: 5.5.6
         version: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.6.0))(eslint@10.6.0)(prettier@3.9.4)
       eslint-plugin-simple-import-sort:
-        specifier: 12.1.1
-        version: 12.1.1(eslint@10.6.0)
+        specifier: 13.0.0
+        version: 13.0.0(eslint@10.6.0)
       globals:
         specifier: 17.7.0
         version: 17.7.0
@@ -1209,8 +1209,8 @@ packages:
       eslint-config-prettier:
         optional: true
 
-  eslint-plugin-simple-import-sort@12.1.1:
-    resolution: {integrity: sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==}
+  eslint-plugin-simple-import-sort@13.0.0:
+    resolution: {integrity: sha512-McAc+/Nlvcg4byY/CABGH8kqnefWBj8s3JA2okEtz8ixbECQgU46p0HkTUKa4YS7wvgGceimlc34p1nXqbWqtA==}
     peerDependencies:
       eslint: '>=5.0.0'
 
@@ -3940,7 +3940,7 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@10.6.0)
 
-  eslint-plugin-simple-import-sort@12.1.1(eslint@10.6.0):
+  eslint-plugin-simple-import-sort@13.0.0(eslint@10.6.0):
     dependencies:
       eslint: 10.6.0
 


### PR DESCRIPTION
## Summary
- One of the 5 deferred majors.
- [v13 changelog](https://github.com/lydell/eslint-plugin-simple-import-sort/blob/main/CHANGELOG.md#version-1300-2026-04-06): imports from the same source but with different styles (namespace + default + named) are now sorted deterministically.
- Behaviorally a no-op here — grep confirms zero files in `src/` or `ci/` import from the same source more than once.

## Test plan
- [x] `pnpm install` clean
- [x] `pnpm run lint` clean (no auto-fixes needed — good sign)
- [x] `pnpm run jest` — 293 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)