### PR TITLE
chore(deps): bump @hansogj/array.utils 2.7.5 → 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "author": "hansogj@gmail.com",
   "license": "UNLICENSED",
   "dependencies": {
-    "@hansogj/array.utils": "2.7.5",
+    "@hansogj/array.utils": "3.0.0",
     "@hansogj/discogs-cover": "1.3.1",
     "@hansogj/discogs-item-lookup": "1.2.2",
     "@hansogj/maybe": "2.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ importers:
   .:
     dependencies:
       '@hansogj/array.utils':
-        specifier: 2.7.5
-        version: 2.7.5
+        specifier: 3.0.0
+        version: 3.0.0
       '@hansogj/discogs-cover':
         specifier: 1.3.1
         version: 1.3.1
@@ -345,8 +345,9 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@hansogj/array.utils@2.7.5':
-    resolution: {integrity: sha512-t8Hlr4arC6RxpuKWcucVTZe8kDdLo6VAaSybtUFKyeeJma+yJd746Y22kfcZFumbRdc4oOkf3yOcSPsbVP+qwA==}
+  '@hansogj/array.utils@3.0.0':
+    resolution: {integrity: sha512-15hdZQJ6fEHJfbMpHRI+EuCeNbqZAv9PjO6/clT4rV2vfY0v4xvPZtBIxmFSvOqNVMKWv3/aL5CGKOwIRNboGA==}
+    engines: {node: '>=18'}
 
   '@hansogj/discogs-cover@1.3.1':
     resolution: {integrity: sha512-kQYZxy9CYlP1Wk+fxNXg/g4dEex4TmSlmNdCiS6P94Kh5qyT4IdEKNFa+7O4yfe45hLP9thUJ3/b1RBgtSiuiQ==}
@@ -2896,7 +2897,7 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@hansogj/array.utils@2.7.5': {}
+  '@hansogj/array.utils@3.0.0': {}
 
   '@hansogj/discogs-cover@1.3.1':
     dependencies:


### PR DESCRIPTION
## Summary
Final of the 5 deferred majors from #57.

**v3 breaking change**: [drops the `./flatMap` sub-entry](https://github.com/hansogj/utils-ws/pull/46). `Array.prototype.flatMap` has been native since Node 11 / ES2019, so the polyfill was dead code. Grep confirms zero references to `@hansogj/array.utils/flatMap` in this repo.

`.defined()` and `.onEmpty()` — the two functions this repo actually uses — are unchanged.

## Test coverage
- 13 source files consume array.utils; all covered by unit tests
- CI integration tests exercise `.defined()` and `.onEmpty()` end-to-end against real FLAC (Led Zeppelin) and MP3 (Accept) fixtures via the tag pipeline
- All 293 unit tests + all 5 CI scripts pass locally on v3

## Test plan
- [x] `pnpm install` clean — v3 installed
- [x] `pnpm run build` clean
- [x] `pnpm run jest` — 293 tests pass
- [ ] CI matrix (22.x / 24.x / 26.x) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)