### PR TITLE
test: cover real gaps + tighten thresholds

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -7,7 +7,7 @@ module.exports = {
     reporters: ['default', ['jest-junit', { outputName: 'junit-TEST.xml' }]],
     coverageThreshold: {
         global: {
-            statements: 50,
+            statements: 90,
             branches: 80,
             functions: 90,
             lines: 90,
@@ -20,7 +20,8 @@ module.exports = {
         "!**/node_modules/**",
         "!**/prompt.ts",
         "!**/color.log.ts",
-        "!**/photo.ts"
+        "!**/photo.ts",
+        "!**/index.ts"
     ],
 
     rootDir: './src',

--- a/src/album/parse.path.test.ts
+++ b/src/album/parse.path.test.ts
@@ -2,10 +2,24 @@ import '../utils/polyfills';
 
 import { DISC_LABEL } from '../constants';
 import { Release } from '../types';
+import * as cmdOptions from '../utils/cmd.options';
+import * as colorLog from '../utils/color.log';
 import * as pathUtils from '../utils/path';
-import { artistSortable, parseAlbumInfo } from './parse.path';
+import { artistSortable, getAlbumDirectory, parseAlbumInfo } from './parse.path';
 
-jest.mock('../utils/color.log');
+jest.mock('../utils/color.log', () => ({
+  error: jest.fn(),
+  info: jest.fn(),
+  warning: jest.fn(),
+  success: jest.fn(),
+  json: jest.fn(),
+  debugInfo: jest.fn(),
+  exit: jest.fn(),
+  default: jest.fn(),
+}));
+jest.mock('../utils/cmd.options', () => ({
+  getCommandLineArgs: jest.fn(),
+}));
 
 describe('artist sort', () => {
   describe.each([
@@ -132,5 +146,43 @@ describe('parse.path', () => {
       pathUtils.readDir.mockReturnValue(lsDir);
     });
     it(`should return ${JSON.stringify({ expected })})`, () => expect(parseAlbumInfo(path)).toEqual(expected));
+  });
+});
+
+describe('getAlbumDirectory', () => {
+  const getCommandLineArgs = cmdOptions.getCommandLineArgs as jest.Mock;
+  const exit = colorLog.exit as jest.Mock;
+  let cwd: jest.SpyInstance;
+  let chdir: jest.SpyInstance;
+
+  beforeEach(() => {
+    cwd = jest.spyOn(process, 'cwd').mockReturnValue('/starting/dir');
+    chdir = jest.spyOn(process, 'chdir').mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    cwd.mockRestore();
+    chdir.mockRestore();
+  });
+
+  it('returns cwd when no --album arg is provided', () => {
+    getCommandLineArgs.mockReturnValue({});
+    expect(getAlbumDirectory()).toEqual('/starting/dir');
+    expect(chdir).not.toHaveBeenCalled();
+  });
+
+  it('chdirs into the album folder and returns the new cwd', () => {
+    getCommandLineArgs.mockReturnValue({ album: 'Some Album' });
+    cwd.mockReturnValueOnce('/starting/dir').mockReturnValue('/starting/dir/Some Album');
+    expect(getAlbumDirectory()).toEqual('/starting/dir/Some Album');
+    expect(chdir).toHaveBeenCalledWith('/starting/dir/Some Album');
+  });
+
+  it('calls exit when chdir throws', () => {
+    getCommandLineArgs.mockReturnValue({ album: 'missing' });
+    chdir.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    getAlbumDirectory();
+    expect(exit).toHaveBeenCalledWith(expect.stringContaining('chdir'));
   });
 });

--- a/src/utils/path.test.ts
+++ b/src/utils/path.test.ts
@@ -1,9 +1,21 @@
 import './polyfills';
 
+import fs from 'node:fs';
+
+import { DISC_NO_SPLIT } from '../constants';
 import { FILETYPE } from '../types';
 import { MockUtil } from './__mocks__/mockutils';
 import * as execute from './execute';
-import { getFileType, getPwd } from './path';
+import {
+  getDirName,
+  getFileType,
+  getPwd,
+  readDir,
+  renameFile,
+  renameFolder,
+  replaceDangers,
+  replaceQuotes,
+} from './path';
 
 jest.mock('./execute');
 const mocks = MockUtil<typeof execute>(jest).requireMocks('./execute');
@@ -17,6 +29,7 @@ describe('path', () => {
     ['Rock and Roll.flac: audio/flac; charset=binary', 'flac' as FILETYPE],
     ['Rock and Roll.mp3: audio/mpeg; charset=binary', 'mp3' as FILETYPE],
     ['folder.jpg: image/jpeg; charset=binary', 'jpg' as FILETYPE],
+    ['song.txt: text/plain; charset=utf-8', 'text' as FILETYPE],
     ['whuut.png: jobbish; charset=binary', 'unknown' as FILETYPE],
   ])('getFileType(%p)', (stdout: string, filetype: FILETYPE) => {
     beforeEach(() => setMockReturnValue(stdout));
@@ -32,5 +45,76 @@ describe('path', () => {
   ])('when current pwd is %s', (currentPath: string, epected: string[]) => {
     beforeEach(() => setMockReturnValue(currentPath));
     it(`getPwd() return ${JSON.stringify({ epected })})`, () => getPwd().then((res) => expect(res).toEqual(epected)));
+  });
+
+  describe('readDir', () => {
+    const entries = ['a.flac', '.hidden', 'b.mp3', '.DS_Store', 'cover.jpg'];
+    let readdirSync: jest.SpyInstance;
+
+    beforeEach(() => {
+      readdirSync = jest.spyOn(fs, 'readdirSync').mockReturnValue(entries as unknown as fs.Dirent[]);
+    });
+    afterEach(() => readdirSync.mockRestore());
+
+    it('filters hidden entries by default', () => {
+      expect(readDir('/some/folder')).toEqual(['a.flac', 'b.mp3', 'cover.jpg']);
+    });
+
+    it('returns everything when filterHidden=false', () => {
+      expect(readDir('/some/folder', false)).toEqual(entries);
+    });
+  });
+
+  describe('getDirName', () => {
+    it('returns process.cwd()', () => {
+      const cwd = jest.spyOn(process, 'cwd').mockReturnValue('/tmp/music');
+      expect(getDirName()).toEqual('/tmp/music');
+      cwd.mockRestore();
+    });
+  });
+
+  describe('renameFolder', () => {
+    it('invokes mv with default root ../', () => {
+      mocks.executeFile.mockReturnValue(Promise.resolve(''));
+      renameFolder('old dir', 'new dir');
+      expect(mocks.executeFile).toHaveBeenCalledWith('mv', ['../old dir', '../new dir']);
+    });
+
+    it('honors an explicit root', () => {
+      mocks.executeFile.mockReturnValue(Promise.resolve(''));
+      renameFolder('a', 'b', '/base/');
+      expect(mocks.executeFile).toHaveBeenCalledWith('mv', ['/base/a', '/base/b']);
+    });
+  });
+
+  describe('renameFile', () => {
+    it('invokes mv with raw src and target', () => {
+      mocks.executeFile.mockReturnValue(Promise.resolve(''));
+      renameFile('foo.flac', 'bar.flac');
+      expect(mocks.executeFile).toHaveBeenCalledWith('mv', ['foo.flac', 'bar.flac']);
+    });
+  });
+
+  describe.each([
+    ['', ''],
+    ['plain text', 'plain text'],
+    ['some "quoted" text', "some 'quoted' text"],
+    ['  double  spaces   collapsed  ', 'double spaces collapsed'],
+  ])('replaceQuotes(%p)', (input: string, expected: string) => {
+    it(`returns ${JSON.stringify(expected)}`, () => expect(replaceQuotes(input)).toEqual(expected));
+  });
+
+  it('replaceQuotes() with no argument returns empty string', () => {
+    expect(replaceQuotes()).toEqual('');
+  });
+
+  describe.each([
+    ['', ''],
+    ['Disc 1/2', `Disc 1${DISC_NO_SPLIT}2`],
+    ['a/b/c', `a${DISC_NO_SPLIT}b${DISC_NO_SPLIT}c`],
+    ['no slashes here', 'no slashes here'],
+    ['mixed "quotes" and / slash', `mixed 'quotes' and ${DISC_NO_SPLIT} slash`],
+  ])('replaceDangers(%p)', (input: string, expected: string) => {
+    it(`returns ${JSON.stringify(expected)}`, () => expect(replaceDangers(input)).toEqual(expected));
   });
 });


### PR DESCRIPTION
## Summary

Topic (2) from the roadmap: test coverage. Focused on the actual gaps rather than chasing every uncovered line.

**New tests (+20):**
- `src/utils/path.ts` — 6 previously untested exports covered: `readDir` (both `filterHidden` branches), `getDirName`, `renameFolder` (default + explicit root), `renameFile`, `replaceQuotes` (including default-param), `replaceDangers`. This file handles character sanitization and file renaming — bugs would corrupt filenames.
- `src/album/parse.path.ts:getAlbumDirectory` — the `--album` CLI shim: no-arg path, chdir success, and the `chdir` throws → `exit` error path.

**Threshold ratchet:**
- `statements: 50 → 90`. The 50 floor was a decade behind reality (~95%). New 90 still has a comfortable buffer.
- Other thresholds unchanged (branches 80 / functions 90 / lines 90) — plenty of margin.

**Coverage cleanup:**
- Exclude `**/index.ts` re-export files from collection. `src/album/index.ts` and `src/similarities/index.ts` were showing 0% purely because tests import from the concrete modules directly.

## Coverage delta

|            | Before | After  |
|------------|--------|--------|
| Statements | 95.56% | **98.88%** |
| Branches   | 87.39% | **90.86%** |
| Functions  | 92.85% | **99.28%** |
| Lines      | 96.20% | **98.64%** |

Test count: 293 → 313.

## Test plan
- [x] `pnpm run precommit` green (jest + jest:ci + CI integration tests + lint + tsc + build)
- [x] All 313 tests pass
- [x] Coverage thresholds all satisfied with buffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)