### PR TITLE
chore(ci): modernize build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: test & build
 on:
   pull_request:
     branches: ['main']
-  workflow_call:
 
 jobs:
   build:
@@ -16,14 +15,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 9
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,10 @@
 packages:
   - 'packages/*'
 
+# Keep in sync with the value baked into pnpm-lock.yaml (settings.injectWorkspacePackages).
+# Without this, pnpm 10's frozen install in CI fails with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+injectWorkspacePackages: true
+
 ignoredBuiltDependencies:
   - unrs-resolver
 


### PR DESCRIPTION
## Summary

**PR 7 of 7** — the final one in the monorepo consolidation series. Modernizes \`build.yml\` and aligns it with \`release.yml\`'s action versions. No behavior change beyond faster CI.

## Changes

- **\`pnpm/action-setup\`**: \`v3\` → \`v4\` — v3 uses Node 20 which GitHub is [deprecating on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/); v4 uses Node 24 (matches \`release.yml\`)
- **pnpm version**: \`9\` → \`10\` — matches local dev and \`release.yml\`
- **Reordered**: pnpm setup now runs before \`actions/setup-node\` so setup-node can discover pnpm and enable its store cache
- **Added \`cache: pnpm\`** on \`actions/setup-node\` — reuses the pnpm store across CI runs, meaningfully speeding up matrix jobs
- **Removed \`workflow_call\`** trigger — was only referenced by the deleted \`bump.yml\`; no other consumers

## Test plan
- [x] \`pnpm run precommit\` green from workspace root
- [ ] CI matrix (22.x / 24.x / 26.x) green — this PR **is** the CI change, so verifying via the PR's own checks

## Monorepo arc — done

With this merged, the seven-PR monorepo consolidation is complete:
1. Scaffold layout (#64)
2. Jest → Vitest (#65)
3. Import discogs-cover (#66)
4. Import discogs-item-lookup (#68)
5. Unify build tooling on tsup (#69)
6. Changesets for per-package releases (#70)
7. CI modernization (this PR)

Plus the drive-by prettier hoist (#67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)