### PR TITLE
feat(config): add JSON config file with library root + folder/track templates

### DIFF
--- a/packages/music-utils/src/album/parse.path.ts
+++ b/packages/music-utils/src/album/parse.path.ts
@@ -2,7 +2,8 @@ import { defined } from '@hansogj/array.utils';
 import maybe from '@hansogj/maybe';
 import path from 'path';
 
-import { DEFINITE_ARTICLES, DISC_NO_SPLIT } from '../constants';
+import { getConfig } from '../config';
+import { DISC_NO_SPLIT } from '../constants';
 import { applyMatch, Parser, regExp } from '../tag/parser';
 import { Release } from '../types';
 import { getCommandLineArgs } from '../utils/cmd.options';
@@ -90,7 +91,10 @@ const calcNoOfDiscsFromPath = (dirName: string, { album, discNumber }: Partial<R
 };
 
 export const artistSortable = (artist: string) => {
-  const matchingPrefix = DEFINITE_ARTICLES.find((prefix) => RegExp(`^${prefix} `, 'i').test(artist));
+  const { sortArticles, articles } = getConfig().artist;
+  if (!sortArticles) return artist;
+
+  const matchingPrefix = articles.find((prefix) => RegExp(`^${prefix} `, 'i').test(artist));
   if (!matchingPrefix) return artist;
 
   return artist

--- a/packages/music-utils/src/config/defaults.ts
+++ b/packages/music-utils/src/config/defaults.ts
@@ -1,0 +1,18 @@
+import { DISC_LABEL, DISC_NO_SPLIT } from '../constants';
+import type { Config } from './schema';
+
+export const DEFAULT_CONFIG: Config = {
+  patterns: {
+    artistFolder: '{artist}',
+    albumFolder: '{year} {album}{discSuffix}{auxSuffix}',
+    track: '{trackNo}{artistPrefix}{title}',
+    trackMultiDisc: 'd{disc}t{trackNo}.{artistPrefix}{title}',
+    artistPrefix: ' {artist} - ',
+    discSuffix: ` (${DISC_LABEL} {disc}${DISC_NO_SPLIT}{total})`,
+    auxSuffix: ' [{aux}]',
+  },
+  artist: {
+    sortArticles: true,
+    articles: ['the', 'los', 'il', 'la', 'el', 'le'],
+  },
+};

--- a/packages/music-utils/src/config/index.ts
+++ b/packages/music-utils/src/config/index.ts
@@ -1,0 +1,5 @@
+export { DEFAULT_CONFIG } from './defaults';
+export { loadConfig } from './load';
+export { renderAlbumFolder, renderArtistFolder, renderTemplate, renderTrackName } from './render';
+export type { Config, PartialConfig } from './schema';
+export { getConfig, resetConfigCache } from './singleton';

--- a/packages/music-utils/src/config/load.test.ts
+++ b/packages/music-utils/src/config/load.test.ts
@@ -1,0 +1,49 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { DEFAULT_CONFIG } from './defaults';
+import { loadConfig } from './load';
+
+describe('loadConfig', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'music-utils-cfg-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns defaults when no config file exists', () => {
+    const cfg = loadConfig(tempDir);
+    expect(cfg.patterns.albumFolder).toBe(DEFAULT_CONFIG.patterns.albumFolder);
+    expect(cfg.artist.sortArticles).toBe(true);
+    expect(cfg.libraryRoot).toBeUndefined();
+  });
+
+  it('picks up ./music-utils.config.json in cwd', () => {
+    writeFileSync(
+      join(tempDir, 'music-utils.config.json'),
+      JSON.stringify({ libraryRoot: '/tmp/library', artist: { sortArticles: false } }),
+    );
+    const cfg = loadConfig(tempDir);
+    expect(cfg.libraryRoot).toBe('/tmp/library');
+    expect(cfg.artist.sortArticles).toBe(false);
+    // Unspecified keys stay at defaults
+    expect(cfg.artist.articles).toEqual(DEFAULT_CONFIG.artist.articles);
+    expect(cfg.patterns.albumFolder).toBe(DEFAULT_CONFIG.patterns.albumFolder);
+  });
+
+  it('merges patterns partially without dropping unspecified keys', () => {
+    writeFileSync(
+      join(tempDir, 'music-utils.config.json'),
+      JSON.stringify({ patterns: { albumFolder: '{album} ({year})' } }),
+    );
+    const cfg = loadConfig(tempDir);
+    expect(cfg.patterns.albumFolder).toBe('{album} ({year})');
+    expect(cfg.patterns.track).toBe(DEFAULT_CONFIG.patterns.track);
+    expect(cfg.patterns.discSuffix).toBe(DEFAULT_CONFIG.patterns.discSuffix);
+  });
+});

--- a/packages/music-utils/src/config/load.ts
+++ b/packages/music-utils/src/config/load.ts
@@ -1,0 +1,45 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+
+import { DEFAULT_CONFIG } from './defaults';
+import type { Config, PartialConfig } from './schema';
+
+const CONFIG_FILE_NAME = 'music-utils.config.json';
+const HOME_CONFIG_FILE_NAME = '.music-utilsrc.json';
+
+const expandHome = (p: string): string => (p.startsWith('~') ? p.replace(/^~/, homedir()) : p);
+
+const readIfExists = (path: string): PartialConfig | null => {
+  if (!existsSync(path)) return null;
+  const raw = readFileSync(path, 'utf8');
+  return JSON.parse(raw) as PartialConfig;
+};
+
+const merge = (base: Config, override: PartialConfig | null): Config => {
+  if (!override) return base;
+  return {
+    ...((override.libraryRoot ?? base.libraryRoot) ? { libraryRoot: override.libraryRoot ?? base.libraryRoot } : {}),
+    patterns: { ...base.patterns, ...(override.patterns ?? {}) },
+    artist: {
+      sortArticles: override.artist?.sortArticles ?? base.artist.sortArticles,
+      articles: override.artist?.articles ?? base.artist.articles,
+    },
+  };
+};
+
+/**
+ * Resolve config in precedence order (first match wins per key):
+ * 1. `./music-utils.config.json`  (cwd — project-local)
+ * 2. `~/.music-utilsrc.json`      (home — user global)
+ * 3. Built-in defaults.
+ *
+ * A missing file at either location is silently skipped.
+ * The returned config has `libraryRoot` fully expanded (~/ resolved).
+ */
+export const loadConfig = (cwd: string = process.cwd()): Config => {
+  const home = readIfExists(resolve(homedir(), HOME_CONFIG_FILE_NAME));
+  const project = readIfExists(resolve(cwd, CONFIG_FILE_NAME));
+  const merged = merge(merge(DEFAULT_CONFIG, home), project);
+  return merged.libraryRoot ? { ...merged, libraryRoot: expandHome(merged.libraryRoot) } : merged;
+};

--- a/packages/music-utils/src/config/render.test.ts
+++ b/packages/music-utils/src/config/render.test.ts
@@ -1,0 +1,82 @@
+import { DISC_LABEL, DISC_NO_SPLIT } from '../constants';
+import type { Release, Track } from '../types';
+import { DEFAULT_CONFIG } from './defaults';
+import { renderAlbumFolder, renderArtistFolder, renderTemplate, renderTrackName } from './render';
+import type { Config } from './schema';
+
+describe('renderTemplate', () => {
+  it('substitutes tokens from vars', () => {
+    expect(renderTemplate('{a}-{b}', { a: 'x', b: 'y' })).toBe('x-y');
+  });
+  it('missing keys resolve to empty string', () => {
+    expect(renderTemplate('{a}{missing}{c}', { a: '1', c: '3' })).toBe('13');
+  });
+  it('unknown tokens with undefined values become empty', () => {
+    expect(renderTemplate('{a}', { a: undefined })).toBe('');
+  });
+  it('leaves non-token text untouched', () => {
+    expect(renderTemplate('literal', {})).toBe('literal');
+  });
+});
+
+describe('renderAlbumFolder', () => {
+  const release: Partial<Release> = { artist: 'Led Zeppelin', album: 'IV', year: '1971' };
+
+  it('renders single-disc default template', () => {
+    expect(renderAlbumFolder(release, DEFAULT_CONFIG)).toBe('1971 IV');
+  });
+
+  it('appends discSuffix when noOfDiscs > 1', () => {
+    expect(renderAlbumFolder({ ...release, discNumber: '1', noOfDiscs: '2' }, DEFAULT_CONFIG)).toBe(
+      `1971 IV (${DISC_LABEL} 1${DISC_NO_SPLIT}2)`,
+    );
+  });
+
+  it('omits discSuffix when noOfDiscs equals 1', () => {
+    expect(renderAlbumFolder({ ...release, discNumber: '1', noOfDiscs: '1' }, DEFAULT_CONFIG)).toBe('1971 IV');
+  });
+
+  it('appends auxSuffix when aux present', () => {
+    expect(renderAlbumFolder({ ...release, aux: 'remaster' }, DEFAULT_CONFIG)).toBe('1971 IV [remaster]');
+  });
+
+  it('honors an overridden template', () => {
+    const cfg: Config = {
+      ...DEFAULT_CONFIG,
+      patterns: { ...DEFAULT_CONFIG.patterns, albumFolder: '{album} - {year}' },
+    };
+    expect(renderAlbumFolder(release, cfg)).toBe('IV - 1971');
+  });
+});
+
+describe('renderArtistFolder', () => {
+  it('uses the artist token by default', () => {
+    expect(renderArtistFolder({ artist: 'Magma' }, DEFAULT_CONFIG)).toBe('Magma');
+  });
+});
+
+describe('renderTrackName', () => {
+  const track: Partial<Track> = { trackName: 'Rock And Roll', trackNo: '01' };
+
+  it('renders single-disc track template', () => {
+    expect(renderTrackName(track, { noOfDiscs: '1' }, DEFAULT_CONFIG)).toBe('01 Rock And Roll');
+  });
+
+  it('renders multi-disc track template when noOfDiscs > 1', () => {
+    expect(renderTrackName({ ...track, discNumber: '2' }, { noOfDiscs: '2' }, DEFAULT_CONFIG)).toBe(
+      'd2t01. Rock And Roll',
+    );
+  });
+
+  it('falls back to release.discNumber when track has none', () => {
+    expect(renderTrackName(track, { discNumber: '1', noOfDiscs: '2' }, DEFAULT_CONFIG)).toBe('d1t01. Rock And Roll');
+  });
+
+  it('honors a template that references {artist}', () => {
+    const cfg: Config = {
+      ...DEFAULT_CONFIG,
+      patterns: { ...DEFAULT_CONFIG.patterns, track: '{trackNo} {artist} - {title}' },
+    };
+    expect(renderTrackName(track, { artist: 'Zep', noOfDiscs: '1' }, cfg)).toBe('01 Zep - Rock And Roll');
+  });
+});

--- a/packages/music-utils/src/config/render.ts
+++ b/packages/music-utils/src/config/render.ts
@@ -1,0 +1,51 @@
+import type { Release, Track } from '../types';
+import type { Config } from './schema';
+
+/** Replace `{token}` occurrences with values from `vars`. Missing keys resolve to ''. */
+export const renderTemplate = (template: string, vars: Record<string, string | undefined>): string =>
+  template.replace(/\{(\w+)\}/g, (_, key: string) => vars[key] ?? '');
+
+const isMultiDisc = (release: Partial<Release>): boolean => {
+  const n = parseInt(release.noOfDiscs ?? '', 10);
+  return Number.isFinite(n) && n > 1;
+};
+
+/** Render the album folder name (last path segment only, no artist prefix). */
+export const renderAlbumFolder = (release: Partial<Release>, config: Config): string => {
+  const { patterns } = config;
+  const discSuffix = isMultiDisc(release)
+    ? renderTemplate(patterns.discSuffix, { disc: release.discNumber, total: release.noOfDiscs })
+    : '';
+  const auxSuffix = release.aux ? renderTemplate(patterns.auxSuffix, { aux: release.aux }) : '';
+  return renderTemplate(patterns.albumFolder, {
+    year: release.year,
+    album: release.album,
+    discSuffix,
+    auxSuffix,
+  })
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+/** Render the artist folder name. */
+export const renderArtistFolder = (release: Partial<Release>, config: Config): string =>
+  renderTemplate(config.patterns.artistFolder, { artist: release.artist });
+
+/**
+ * Render a track filename (excluding the file extension).
+ *
+ * Uses `trackMultiDisc` when the track has an explicit `discNumber` or the
+ * release spans multiple discs; otherwise `track`.
+ */
+export const renderTrackName = (track: Partial<Track>, release: Partial<Release>, config: Config): string => {
+  const useMultiDisc = isMultiDisc(release) || track.discNumber !== undefined;
+  const template = useMultiDisc ? config.patterns.trackMultiDisc : config.patterns.track;
+  const artistPrefix = release.artist ? renderTemplate(config.patterns.artistPrefix, { artist: release.artist }) : ' ';
+  return renderTemplate(template, {
+    disc: track.discNumber ?? release.discNumber,
+    trackNo: track.trackNo,
+    title: track.trackName,
+    artist: release.artist,
+    artistPrefix,
+  });
+};

--- a/packages/music-utils/src/config/schema.ts
+++ b/packages/music-utils/src/config/schema.ts
@@ -1,0 +1,32 @@
+export interface Config {
+  /** Base directory for `music-utils-rip` — where new albums land. Tilde is expanded. When unset, callers should fall back to `process.cwd()`. */
+  libraryRoot?: string;
+  patterns: {
+    /** Directory name for the artist (default: "{artist}"). */
+    artistFolder: string;
+    /** Directory name for the album (default: "{year} {album}{discSuffix}{auxSuffix}"). */
+    albumFolder: string;
+    /** Track filename when the release is single-disc (default: "{trackNo}{artistPrefix}{title}"). */
+    track: string;
+    /** Track filename when the release spans multiple discs (default: "d{disc}t{trackNo}.{artistPrefix}{title}"). */
+    trackMultiDisc: string;
+    /** Rendered before {title} when release.artist is present (default: " {artist} - "; falls back to " "). */
+    artistPrefix: string;
+    /** Appended to albumFolder when noOfDiscs > 1 (default: " (Disc {disc}∕{total})"). */
+    discSuffix: string;
+    /** Appended to albumFolder when aux info is present (default: " [{aux}]"). */
+    auxSuffix: string;
+  };
+  artist: {
+    /** Move definite articles to the end during folder naming ("The Beatles" → "Beatles, The"). */
+    sortArticles: boolean;
+    /** Which words to treat as definite articles for the sort. */
+    articles: string[];
+  };
+}
+
+export type PartialConfig = {
+  libraryRoot?: string;
+  patterns?: Partial<Config['patterns']>;
+  artist?: Partial<Config['artist']>;
+};

--- a/packages/music-utils/src/config/singleton.ts
+++ b/packages/music-utils/src/config/singleton.ts
@@ -1,0 +1,15 @@
+import { loadConfig } from './load';
+import type { Config } from './schema';
+
+let cached: Config | undefined;
+
+/**
+ * Returns the resolved configuration, loading it on first access.
+ * Subsequent calls return the cached value.
+ */
+export const getConfig = (): Config => (cached ??= loadConfig());
+
+/** Test helper: force a re-load on next `getConfig()` call. */
+export const resetConfigCache = (): void => {
+  cached = undefined;
+};

--- a/packages/music-utils/src/run/rip.ts
+++ b/packages/music-utils/src/run/rip.ts
@@ -12,7 +12,7 @@ import { DiscogsApiError, lookupRelease, LookupReleaseOptions, LookupResult } fr
 import * as dotenv from 'dotenv';
 
 import { tagAlbum } from '../album';
-import { DISC_NO_SPLIT } from '../constants';
+import { getConfig, renderAlbumFolder, renderArtistFolder } from '../config';
 import { coverFromDiscogs } from '../covers/photo';
 import { Release } from '../types';
 import { getCommandLineArgs } from '../utils/cmd.options';
@@ -89,15 +89,6 @@ function formatTracklist(tracks: { position: string; title: string }[]): string 
     })
     .map(({ title }) => title.trim())
     .join('\n');
-}
-
-function buildFolderName(release: Partial<Release>): string {
-  const safeTitle = sanitizePath(release.album ?? '');
-  const { discNumber, noOfDiscs, aux } = release;
-  const discSuffix =
-    noOfDiscs && parseInt(noOfDiscs, 10) > 1 ? ` (Disc ${discNumber}${DISC_NO_SPLIT}${noOfDiscs})` : '';
-  const auxSuffix = aux ? ` [${aux}]` : '';
-  return `${release.year} ${safeTitle}${discSuffix}${auxSuffix}`;
 }
 
 async function convertWavFilesToFlac(): Promise<void> {
@@ -177,9 +168,14 @@ async function main({ releaseId, disc }: Pick<LookupReleaseOptions, 'disc' | 're
     };
 
     const confirmed = await albumPrompt(releaseInfo);
-    const safeArtist = sanitizePath(confirmed.artist ?? '');
-    const folderName = buildFolderName(confirmed);
-    const fullPath = join(safeArtist, folderName);
+    const safeRelease: Partial<Release> = {
+      ...confirmed,
+      artist: sanitizePath(confirmed.artist ?? ''),
+      album: sanitizePath(confirmed.album ?? ''),
+    };
+    const cfg = getConfig();
+    const libraryRoot = cfg.libraryRoot ?? process.cwd();
+    const fullPath = join(libraryRoot, renderArtistFolder(safeRelease, cfg), renderAlbumFolder(safeRelease, cfg));
 
     console.log(`\n📁 Creating directory: ${fullPath}`);
     await mkdir(fullPath, { recursive: true });

--- a/packages/music-utils/src/utils/sync.tag.path.ts
+++ b/packages/music-utils/src/utils/sync.tag.path.ts
@@ -2,48 +2,65 @@ import './polyfills';
 
 import { defined } from '@hansogj/array.utils';
 
-import { DISC_LABEL, DISC_NO_SPLIT } from '../constants';
+import { getConfig, renderAlbumFolder, renderTrackName } from '../config';
 import { File, Release } from '../types';
 import { debugInfo } from './color.log';
-import { precedingZero, toIntOr } from './number';
+import { precedingZero } from './number';
 import { renameFile, renameFolder } from './path';
 import { toLowerCase } from './string';
 
 export const syncReleaseFolder = (release: Release, dirName = ''): Promise<Release> => {
-  const { discNumber, noOfDiscs, year, album } = release || ({} as Release);
   const src = dirName.split('/').pop();
-
-  const aux = release?.aux && `[${release.aux}]`;
-  const disc =
-    [discNumber, noOfDiscs].every(defined) &&
-    toIntOr(noOfDiscs ?? '0', 0) > 1 &&
-    `(${DISC_LABEL} ${[discNumber, noOfDiscs].defined().join(DISC_NO_SPLIT)})`;
-  const target = [year, album, disc, aux].defined().join(' ');
+  const target = renderAlbumFolder(release ?? {}, getConfig());
 
   const shouldRename = defined(src) && toLowerCase(target) !== toLowerCase(src);
   debugInfo({ msg: shouldRename ? 'rename album folder name' : 'keeping', src, target });
   return shouldRename ? renameFolder(src!, target).then(() => release) : Promise.resolve(release);
 };
 
+interface NormalizedTrack {
+  disc?: string;
+  trackNo?: string;
+  trackName?: string;
+}
+
+/**
+ * Split a 3+-digit trackNo into its encoded disc + track components, and
+ * left-pad the track number when it would look better with a leading zero.
+ */
+const normalizeTrack = (
+  trackNo: string | undefined,
+  trackDisc: string | undefined,
+  releaseDisc: string | undefined,
+): NormalizedTrack => {
+  const disc = trackDisc || releaseDisc;
+
+  if ((trackNo?.length ?? 0) > 2) {
+    const [encodedDisc, ...rest] = trackNo!.split('');
+    return { disc: trackDisc ?? encodedDisc, trackNo: rest.join('') };
+  }
+
+  // Pad only in the multi-disc branch and only if trackNo is < 2 chars — matches pre-refactor behavior.
+  const needsPad =
+    disc !== undefined &&
+    (trackNo?.length ?? 0) < 2 &&
+    precedingZero(parseInt(disc, 10), parseInt(trackNo ?? '0', 10)) === 0;
+  return { disc, trackNo: trackNo ? `${needsPad ? '0' : ''}${trackNo}` : trackNo };
+};
+
 export const syncTrackNames = (files: File[] = [], release?: Release) =>
   Promise.all(
-    files.map(({ path, fileType, track: { trackName, trackNo, discNumber } = {} }) => {
+    files.map(({ path, fileType, track = {} }) => {
       const src = `${path}`.split('/').pop();
-      const discNr = discNumber || release?.discNumber;
-      const zero = precedingZero(parseInt(discNr ?? '0', 10), parseInt(trackNo ?? '0', 10)) === 0 ? '0' : '';
-      const artistSection = release?.artist ? ` ${release?.artist} - ` : ' ';
-      let sortableTrackNumber: string | undefined = discNr ? `d${discNr}t${zero}${trackNo}.` : trackNo;
-
-      if ((trackNo?.length ?? 0) > 2) {
-        const [discNoFromTrack, ...rest] = trackNo!.split('');
-        sortableTrackNumber = discNr ? `d${discNr}t${rest.join('')}.` : `d${discNoFromTrack}t${rest.join('')}.`;
-      }
+      const { disc, trackNo } = normalizeTrack(track.trackNo, track.discNumber, release?.discNumber);
+      const trackName = track.trackName;
 
       const target =
-        [trackName, sortableTrackNumber].every((e) => defined(e)) &&
-        `${sortableTrackNumber}${artistSection}${trackName}.${fileType}`;
+        defined(trackName) && defined(trackNo)
+          ? `${renderTrackName({ trackName, trackNo, discNumber: disc }, release ?? {}, getConfig())}.${fileType}`
+          : undefined;
 
-      debugInfo({ trackName, trackNo, sortableTrackNumber, discNr });
+      debugInfo({ trackName, trackNo, disc });
       debugInfo(`mv  ${src}  ${target}`);
       return defined(target) && target !== src
         ? renameFile(src!, `${target}`).then(() => files)


### PR DESCRIPTION
## Summary

Introduces a JSON config file so `music-utils-rip` can be run from anywhere and folder/track naming can be customized. Scope: Tier 1 knobs only (library root, folder/track templates, article-sort toggle).

## Resolution order

First-match-wins, per key:

1. `./music-utils.config.json` (project-local, e.g. per-library)
2. `~/.music-utilsrc.json` (user global)
3. Built-in defaults

## Configurable keys

- **`libraryRoot`** — anchor for `music-utils-rip`. When unset, falls back to `process.cwd()` (zero behavior change for anyone without a config). When set (with `~` expansion), `music-utils-rip -r <id>` works from any cwd.
- **`patterns.{artistFolder,albumFolder,track,trackMultiDisc,artistPrefix,discSuffix,auxSuffix}`** — templated with `{token}` substitution over `{artist}`, `{album}`, `{year}`, `{disc}`, `{total}`, `{trackNo}`, `{title}`, `{aux}`, `{discSuffix}`, `{auxSuffix}`, `{artistPrefix}`. Defaults preserve today's format (`{year} {album} (Disc N∕M) [aux]`, `d{disc}t{trackNo}.{artist} - {title}`).
- **`artist.sortArticles`** / **`artist.articles`** — on/off toggle plus configurable article list for the "The Beatles" → "Beatles, The" sort transform. Article list previously hardcoded to `['the','los','il','la','el','le']`.

## Rendering

- `syncReleaseFolder` and `syncTrackNames` now call the shared `renderAlbumFolder` / `renderTrackName`.
- `rip.ts` drops the local `buildFolderName` duplicate (which reimplemented the disc/aux logic) and anchors its `mkdir` at `libraryRoot ?? process.cwd()`.

## Explicitly out of scope (deferred to future PRs)

- Cover art filename + resolution
- Disc separator char
- Tracks-file name, FLAC compression level, User-Agent, etc.
- CLI flag override (config file only for now)

## Test plan

- [x] `pnpm run vitest` — 330/330 pass (14 new render tests + 3 new load tests)
- [x] `pnpm run vitest:ci` — coverage report clean, thresholds met
- [x] `pnpm run ci:run-all` — tag:tracks, tag:zep1, tag:zep2, tag:acc, prompt all PASSED against real test-data files
- [x] `pnpm run precommit` — full chain green (test + lint + format + tsc + build) across all 3 workspace packages via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)