### PR TITLE
fix(music-utils): whitelist build/ for npm publish to avoid leaking .env

### DIFF
--- a/packages/music-utils/package.json
+++ b/packages/music-utils/package.json
@@ -39,6 +39,9 @@
     "test": "run-s vitest vitest:ci ci:run-all",
     "precommit": "run-s test lint format:check tsc build"
   },
+  "files": [
+    "build"
+  ],
   "keywords": [
     "music",
     "flac",


### PR DESCRIPTION
## Summary

Precondition for publishing \`@hansogj/music-utils\` to npm. Without this, the release workflow would tarball the local \`.env\` (real DISCOGS_TOKEN), \`coverage/\` HTML reports, \`test-data/\` FLAC binaries, source, tests, and tsconfigs — 211 files, several containing secrets or bulk.

## Change

Add an explicit \`files\` allowlist to \`packages/music-utils/package.json\`:

\`\`\`json
"files": ["build"]
\`\`\`

Matches the sibling packages' convention (\`discogs-cover\` and \`discogs-item-lookup\` both use \`files: [\"dist\"]\`; music-utils outputs to \`build/\`).

## Verification

Ran \`pnpm pack\` before and after:

| | Before | After |
|---|---|---|
| File count | 211 | 45 |
| \`.env\` included? | **yes** (with real token) | no |
| \`coverage/\`? | yes | no |
| \`test-data/\` (FLAC binaries)? | yes | no |
| \`src/\` / tests / tsconfigs? | yes | no |
| Contains | build/ + everything else | build/ + package.json + README.md |

## Why now

The \`release\` workflow has been failing since PR #70 with \`ENEEDAUTH\` (no NPM_TOKEN secret), which masked the fact that when it *did* eventually try to publish, it would have leaked the developer's local \`.env\`. With this in place + an NPM_TOKEN secret, publishing is safe.

## Follow-ups (separate)

- Add the \`NPM_TOKEN\` repo secret so the release workflow can actually authenticate.
- Consider emitting \`.d.ts\` alongside \`.js\` if \`@hansogj/music-utils\` is ever meant to be imported as a library. Currently CLI-only (\`bin\` field), so types are optional.

## Test plan

- [x] \`pnpm pack --pack-destination /tmp\` — tarball reduced 211 → 45 files
- [x] Verified no \`.env\`, \`coverage/\`, \`test-data/\`, source, or tests remain in tarball
- [x] Full \`pnpm precommit\` chain green across all 3 workspace packages (via pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)