### PR TITLE
docs(music-utils): refresh README for npm publish + config file

### DIFF
--- a/packages/music-utils/README.md
+++ b/packages/music-utils/README.md
@@ -1,35 +1,98 @@
 [![example workflow](https://github.com/hansogj/music-utils/actions/workflows/build.yml/badge.svg)](https://github.com/hansogj/music-utils/actions/workflows/build.yml/badge.svg)
 
-# Dependencies
+# @hansogj/music-utils
 
-install following dependencies
+TypeScript CLI toolkit for managing FLAC and MP3 music collections. Handles CD ripping, tag reading/writing, Discogs metadata lookup, cover art fetching, and folder-structure normalization.
+
+# External dependencies
+
+The CLIs shell out to a handful of system tools. Install them first:
 
 ```bash
 sudo apt install \
-id3v2 \
-flac \
-cdparanoia
+  id3v2 \
+  flac \
+  cdparanoia \
+  ffmpeg \
+  file
 ```
+
+`ffmpeg` provides `ffprobe`; `flac` provides `metaflac`; `file` is used to detect audio-file type.
 
 # Installation
 
-```
-pnpm install && pnpm run build
-```
-
-Add your discogs secret token to .env in this project's root folder (it is not committed)
+## From npm
 
 ```
-DISCOGS_TOKEN="###SUPER_DUPER_SECRET###"
-```
-
-Link the CLI commands globally:
-
-```
-pnpm link --global
+npm install -g @hansogj/music-utils
 ```
 
 This makes all `music-utils-*` commands available in your terminal.
+
+## From source
+
+```
+pnpm install
+pnpm --filter @hansogj/music-utils run build
+pnpm --filter @hansogj/music-utils link --global
+```
+
+# Environment
+
+Every command that talks to Discogs needs a personal access token. Put it in a `.env` at the project root (source install) or export it in your shell (npm install):
+
+```
+DISCOGS_TOKEN="###YOUR_DISCOGS_TOKEN###"
+```
+
+# Configuration
+
+Folder naming, track filenames, and the library root are configurable via a JSON file. Precedence (first match wins per key):
+
+1. `./music-utils.config.json` in the current directory (project-local, e.g. per library)
+2. `~/.music-utilsrc.json` in your home directory (user-global)
+3. Built-in defaults
+
+Every key is optional; anything you omit falls back to the default.
+
+## Schema
+
+```json
+{
+  "libraryRoot": "~/Music",
+  "patterns": {
+    "artistFolder": "{artist}",
+    "albumFolder": "{year} {album}{discSuffix}{auxSuffix}",
+    "track": "{trackNo}{artistPrefix}{title}",
+    "trackMultiDisc": "d{disc}t{trackNo}.{artistPrefix}{title}",
+    "artistPrefix": " {artist} - ",
+    "discSuffix": " (Disc {disc}∕{total})",
+    "auxSuffix": " [{aux}]"
+  },
+  "artist": {
+    "sortArticles": true,
+    "articles": ["the", "los", "il", "la", "el", "le"]
+  }
+}
+```
+
+### `libraryRoot`
+
+Base directory for `music-utils-rip`. When set (tildes are expanded), rips land here regardless of your current working directory — you can run `music-utils-rip -r <id>` from anywhere. When unset, rips land relative to `process.cwd()`.
+
+### `patterns.*`
+
+Templates use `{token}` substitution. Available tokens: `{artist}`, `{album}`, `{year}`, `{disc}`, `{total}`, `{trackNo}`, `{title}`, `{aux}`, `{discSuffix}`, `{auxSuffix}`, `{artistPrefix}`. Missing tokens resolve to empty and surrounding whitespace collapses.
+
+- `artistFolder` / `albumFolder` — the two path segments `music-utils-*` writes into.
+- `track` / `trackMultiDisc` — filename (without extension) for single-disc vs multi-disc releases.
+- `artistPrefix` — inserted before `{title}` when the release has an artist; renders to `' '` otherwise.
+- `discSuffix` — appended to `albumFolder` when `noOfDiscs > 1`. Note: the character between disc/total is `∕` (U+2215 division slash), not `/`, because filesystems reject `/` in path segments.
+- `auxSuffix` — appended when the album has aux info (e.g. `[remaster]`).
+
+### `artist.sortArticles` / `artist.articles`
+
+When `true`, definite articles listed in `articles` move to the end during folder naming: `"The Beatles" → "Beatles, The"`. Set `false` to keep the article in place, or replace `articles` with your own list.
 
 # Features
 
@@ -38,11 +101,10 @@ This makes all `music-utils-*` commands available in your terminal.
 ### Usage
 
 ```
-Music/Artist $> music-utils-rip -r <releaseId> -d <disc-number?>
+$> music-utils-rip -r <releaseId> -d <disc-number?>
 ```
 
-`<releaseId>` refers to the Discogs item id, disc-number if there are more than 1 disc.
-Creates a folder `Artist/YYYY Album Name` from your current position, rips the CD (via _cdparanoia_), converts WAV to FLAC, renames files, sets tags and fetches cover photo. All based on info from Discogs.
+`<releaseId>` is the Discogs item id; `<disc-number>` is used when there is more than one disc. Creates a folder `Artist/YYYY Album Name` (under `libraryRoot` if configured, otherwise the current directory), rips the CD via `cdparanoia`, converts WAV to FLAC, renames files, sets tags, and fetches the cover photo — all based on info from Discogs.
 
 ## cover-photo
 
@@ -50,9 +112,6 @@ Creates a folder `Artist/YYYY Album Name` from your current position, rips the C
 
 ```
 Music/Artist/2020 Album $> music-utils-cover-photo --releaseId <id>
-```
-
-```
 Music/Artist/2020 Album $> music-utils-cover-photo
 ```
 
@@ -121,7 +180,7 @@ Finds similar artist names across directories (e.g. `A Band` vs `Band, A`).
 ### Usage
 
 ```
-/> music-utils-similarities -A /path/to/origin/ -B /path/to/comparator/ -T 0.5 -Q
+$> music-utils-similarities -A /path/to/origin/ -B /path/to/comparator/ -T 0.5 -Q
 ```
 
 - **-A** base directory


### PR DESCRIPTION
## Summary

Overdue cleanup ahead of the first npm publish of \`@hansogj/music-utils\`. Content-only; no code or workflow changes.

## Changes

- **Header**: swap the bare "Dependencies" heading for a package name + one-sentence description.
- **Installation**: split into **From npm** (\`npm install -g @hansogj/music-utils\`) and **From source** (\`pnpm install\`, workspace-scoped build, workspace-scoped link). Previous instructions only covered source.
- **Configuration**: full section documenting the JSON config file introduced in #72 — precedence order (\`./music-utils.config.json\` → \`~/.music-utilsrc.json\` → defaults), the full schema with default values, and per-key notes (\`libraryRoot\`, \`patterns.*\`, \`artist.*\`).
- **External dependencies**: expand the apt list to include \`ffmpeg\` (provides \`ffprobe\`) and \`file\` — both were being shelled out to but not documented.
- **Environment**: clarify DISCOGS_TOKEN placement for both install paths.

## Follow-ups (separate)

- The \`music-utils-similarities\` bin gets dropped by npm with a pre-existing warning (\`"bin[music-utils-similarities]" script name build/run/similarities.js was invalid and removed\`). Not fixed here.
- Publish \`@hansogj/music-utils@1.3.32\` to npm manually once this lands, then configure Trusted Publisher on npmjs.com and switch the release workflow to OIDC + provenance (deferred: #TBD).

## Test plan

- [x] Full \`pnpm precommit\` chain green across all 3 workspace packages (via pre-commit hook)
- [x] Rendered README locally — links, code fences, and schema block all look right

🤖 Generated with [Claude Code](https://claude.com/claude-code)