### PR TITLE
fix(music-utils): drop ./ prefix from bin paths for npm publish

### DIFF
--- a/packages/music-utils/package.json
+++ b/packages/music-utils/package.json
@@ -4,15 +4,15 @@
   "description": "music tools for my flac & mp3 collection",
   "main": "",
   "bin": {
-    "music-utils-rip": "./build/run/rip.js",
-    "music-utils-album-tag": "./build/run/tag.album.js",
-    "music-utils-tracks-tag": "./build/run/tag.tracks.js",
-    "music-utils-cover-photo": "./build/run/cover.photo.js",
-    "music-utils-album-cover": "./build/run/tag.cover.album.js",
-    "music-utils-bulk-album-tag": "./build/run/bulk.tag.album.js",
-    "music-utils-bulk-cover-photo": "./build/run/bulk.cover.photo.js",
-    "music-utils-sync-tracks": "./build/run/sync.track.names.js",
-    "music-utils-similarities": "./build/run/similarities.js"
+    "music-utils-rip": "build/run/rip.js",
+    "music-utils-album-tag": "build/run/tag.album.js",
+    "music-utils-tracks-tag": "build/run/tag.tracks.js",
+    "music-utils-cover-photo": "build/run/cover.photo.js",
+    "music-utils-album-cover": "build/run/tag.cover.album.js",
+    "music-utils-bulk-album-tag": "build/run/bulk.tag.album.js",
+    "music-utils-bulk-cover-photo": "build/run/bulk.cover.photo.js",
+    "music-utils-sync-tracks": "build/run/sync.track.names.js",
+    "music-utils-similarities": "build/run/similarities.js"
   },
   "minimumReleaseAge": 10800,
   "scripts": {


### PR DESCRIPTION
## Summary

Current npm rejects \`bin\` values with a leading \`./\` — it silently strips every entry with:

\`\`\`
"bin[music-utils-rip]" script name build/run/rip.js was invalid and removed
\`\`\`

When we tried the first publish of \`@hansogj/music-utils\` right after PR #74, this would have shipped **a package with zero working CLIs** to anyone running \`npm install -g @hansogj/music-utils\`. All nine entries were being rejected. The initial dry-run only surfaced one warning because the output was tail-truncated; the actual \`npm publish\` showed all nine.

The publish itself failed at the 2FA prompt (EOTP), so nothing hit the registry. This PR is the fix before we retry.

## Change

What \`npm pkg fix\` proposes for all nine entries:

\`\`\`diff
-  "music-utils-rip": "./build/run/rip.js",
+  "music-utils-rip": "build/run/rip.js",
\`\`\`

...and equivalent for the other eight. The bin symlinks work identically at install time — this is purely npm-side validation strictness.

## Verification

- Before: 9 \`invalid and removed\` warnings, 44 files
- After: 0 warnings, 44 files, all 9 bin entries preserved in \`npm publish --dry-run\`

## Test plan

- [x] \`npm publish --access public --dry-run\` — zero warnings, all bin entries reported intact
- [x] Full \`pnpm precommit\` chain green across all 3 workspace packages (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)