### PR TITLE
feat(music-utils): configurable tracks file + docs refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# music-utils monorepo
+
+TypeScript toolkit for managing a personal FLAC/MP3 music collection. Three packages, published independently to npm:
+
+| Package | Description |
+|---------|-------------|
+| [`@hansogj/music-utils`](./packages/music-utils) | Top-level CLI suite: CD ripping via `cdparanoia`, tag reading/writing, Discogs metadata lookup, cover art fetching, folder-structure normalization. Depends on the other two. |
+| [`@hansogj/discogs-item-lookup`](./packages/discogs-item-lookup) | Standalone client + CLI for fetching release metadata from the Discogs API. |
+| [`@hansogj/discogs-cover`](./packages/discogs-cover) | Standalone client + CLI for fetching and downloading album cover art from Discogs. |
+
+The typical end-user only installs `@hansogj/music-utils` (which brings the other two along transitively). The lower-level packages are useful on their own if you just need Discogs lookups or covers without the ripping/tagging pipeline.
+
+## Development
+
+Package manager: **pnpm** (enforced via preinstall hook). Node 25.x via Volta.
+
+```bash
+pnpm install
+pnpm --filter @hansogj/music-utils run test
+pnpm --filter @hansogj/music-utils run precommit
+```
+
+Per-package scripts live in each `packages/*/package.json`; the workspace root has a monorepo-wide `precommit` that runs each package's `precommit` sequentially (via `pnpm -r`).
+
+### Releases
+
+Managed via [Changesets](https://github.com/changesets/changesets). Adding a changeset:
+
+```bash
+pnpm changeset          # interactive: pick packages + bump type + write summary
+```
+
+The `release` workflow on `main` picks up changesets, opens a "Version Packages" PR that bumps versions and updates `CHANGELOG.md`, and on merge publishes the affected packages to npm.

--- a/packages/music-utils/README.md
+++ b/packages/music-utils/README.md
@@ -60,6 +60,7 @@ Every key is optional; anything you omit falls back to the default.
 ```json
 {
   "libraryRoot": "~/Music",
+  "tracksFile": "tracks.txt",
   "patterns": {
     "artistFolder": "{artist}",
     "albumFolder": "{year} {album}{discSuffix}{auxSuffix}",
@@ -79,6 +80,10 @@ Every key is optional; anything you omit falls back to the default.
 ### `libraryRoot`
 
 Base directory for `music-utils-rip`. When set (tildes are expanded), rips land here regardless of your current working directory — you can run `music-utils-rip -r <id>` from anywhere. When unset, rips land relative to `process.cwd()`.
+
+### `tracksFile`
+
+Default path used by `music-utils-tracks-tag` when `-f` is not supplied. Relative paths are resolved against `process.cwd()`; an absolute path is used as-is. Precedence: CLI `-f` > this key > default `"tracks.txt"`.
 
 ### `patterns.*`
 
@@ -138,9 +143,16 @@ Parses directory structure to extract artist/album info, extracts tags from each
 
 ```
 Music/Artist/2020 Album $> music-utils-tracks-tag -f /path/to/tracks.txt
+Music/Artist/2020 Album $> music-utils-tracks-tag                          # uses config.tracksFile
 ```
 
-Like _album-tag_ but uses track names from the provided `tracks.txt` file.
+Like _album-tag_ but reads track names from an external file (one title per line) instead of relying on tags already present. Path resolution:
+
+1. `-f <file>` CLI flag (highest priority)
+2. `tracksFile` from your config (`music-utils.config.json` / `~/.music-utilsrc.json`)
+3. Default `tracks.txt` in the current working directory
+
+Handy after `music-utils-rip`, which writes a `tracks.txt` for the album at rip time and then chdirs into the album folder — running `music-utils-tracks-tag` there with the default resolution just works.
 
 ## album-cover (cover + tag combo)
 
@@ -175,18 +187,23 @@ Fetches cover photos for all subdirectories that don't already have a `.jpg` fil
 
 ## similarities
 
-Finds similar artist names across directories (e.g. `A Band` vs `Band, A`).
+Fuzzy-matches artist directory names across two roots so you can spot duplicates when merging or comparing music libraries. Typical use: you kept a backup on one drive and a working library on another, and the same artist has drifted into `A Band` in one place and `Band, A` in the other. `similarities` surfaces those pairs.
+
+It scans `-A` one level deep for artist directories and `-B` two levels deep (assuming `Artist/Album` layout), strips a configurable set of ignore-words from each name (definite articles, "and", "band", etc.), then compares via string similarity. Pairs scoring above `-T` are reported.
 
 ### Usage
 
 ```
-$> music-utils-similarities -A /path/to/origin/ -B /path/to/comparator/ -T 0.5 -Q
+$> music-utils-similarities -A /path/to/library-A/ -B /path/to/library-B/ -T 0.5 -Q
+$> music-utils-similarities -A ./ -B /mnt/backup/Music/ -T 0.7 -F matches.json
 ```
 
-- **-A** base directory
-- **-B** comparing directory
-- **-T** threshold of equality
-- **-Q** quiet mode
+- **`-A <path>`** base directory (artist folders directly under this)
+- **`-B <path>`** comparison directory (searched two levels deep for `Artist/Album`)
+- **`-T <0..1>`** similarity threshold; higher is stricter (0.5 = loose, 0.8 = tight)
+- **`-F <file>`** optional; write results to `<file>` as JSON in addition to logging them
+- **`--ignore <word>`** words to strip before comparing (repeatable); merged with the built-in list
+- **`-Q`** quiet mode; suppress timing/progress logs
 
 ## sync-tracks
 
@@ -196,4 +213,6 @@ $> music-utils-similarities -A /path/to/origin/ -B /path/to/comparator/ -T 0.5 -
 Music/Artist/2020 Album $> music-utils-sync-tracks
 ```
 
-Synchronizes track filenames with parsed album metadata.
+Renames audio files in the current album folder to reflect the tags already on them. Reads each file's tags, parses the folder path for artist/album/year context, then applies the configured `patterns.track` / `patterns.trackMultiDisc` templates to compute the target filename. The tags themselves are not rewritten — this is filename-only.
+
+Useful when the tags are already correct (e.g. from another program) but the filenames don't match, or when you've changed your `patterns.*` config and want existing files to catch up.

--- a/packages/music-utils/src/config/defaults.ts
+++ b/packages/music-utils/src/config/defaults.ts
@@ -1,7 +1,8 @@
-import { DISC_LABEL, DISC_NO_SPLIT } from '../constants';
+import { DISC_LABEL, DISC_NO_SPLIT, TRACKS_FILE_NAME } from '../constants';
 import type { Config } from './schema';
 
 export const DEFAULT_CONFIG: Config = {
+  tracksFile: TRACKS_FILE_NAME,
   patterns: {
     artistFolder: '{artist}',
     albumFolder: '{year} {album}{discSuffix}{auxSuffix}',

--- a/packages/music-utils/src/config/load.test.ts
+++ b/packages/music-utils/src/config/load.test.ts
@@ -21,6 +21,13 @@ describe('loadConfig', () => {
     expect(cfg.patterns.albumFolder).toBe(DEFAULT_CONFIG.patterns.albumFolder);
     expect(cfg.artist.sortArticles).toBe(true);
     expect(cfg.libraryRoot).toBeUndefined();
+    expect(cfg.tracksFile).toBe(DEFAULT_CONFIG.tracksFile);
+  });
+
+  it('overrides tracksFile from config file', () => {
+    writeFileSync(join(tempDir, 'music-utils.config.json'), JSON.stringify({ tracksFile: 'my.tracks.txt' }));
+    const cfg = loadConfig(tempDir);
+    expect(cfg.tracksFile).toBe('my.tracks.txt');
   });
 
   it('picks up ./music-utils.config.json in cwd', () => {

--- a/packages/music-utils/src/config/load.ts
+++ b/packages/music-utils/src/config/load.ts
@@ -20,6 +20,7 @@ const merge = (base: Config, override: PartialConfig | null): Config => {
   if (!override) return base;
   return {
     ...((override.libraryRoot ?? base.libraryRoot) ? { libraryRoot: override.libraryRoot ?? base.libraryRoot } : {}),
+    tracksFile: override.tracksFile ?? base.tracksFile,
     patterns: { ...base.patterns, ...(override.patterns ?? {}) },
     artist: {
       sortArticles: override.artist?.sortArticles ?? base.artist.sortArticles,

--- a/packages/music-utils/src/config/schema.ts
+++ b/packages/music-utils/src/config/schema.ts
@@ -1,6 +1,8 @@
 export interface Config {
   /** Base directory for `music-utils-rip` — where new albums land. Tilde is expanded. When unset, callers should fall back to `process.cwd()`. */
   libraryRoot?: string;
+  /** Default path for `music-utils-tracks-tag` when `-f` is not supplied. Relative paths are resolved against `process.cwd()`. */
+  tracksFile: string;
   patterns: {
     /** Directory name for the artist (default: "{artist}"). */
     artistFolder: string;
@@ -27,6 +29,7 @@ export interface Config {
 
 export type PartialConfig = {
   libraryRoot?: string;
+  tracksFile?: string;
   patterns?: Partial<Config['patterns']>;
   artist?: Partial<Config['artist']>;
 };

--- a/packages/music-utils/src/run/tag.tracks.ts
+++ b/packages/music-utils/src/run/tag.tracks.ts
@@ -4,7 +4,7 @@ import path from 'path';
 
 import { tagAlbum } from '../album';
 import { getAlbumDirectory } from '../album/parse.path';
-import { TRACKS_FILE_NAME } from '../constants';
+import { getConfig } from '../config';
 import { getCommandLineArgs } from '../utils/cmd.options';
 import { error, exit, info, json } from '../utils/color.log';
 import { replaceDangers } from '../utils/path';
@@ -13,7 +13,7 @@ import { syncTrackNames } from '../utils/sync.tag.path';
 const { fileName } = getCommandLineArgs();
 let tracks;
 
-const tracksFile = fileName || path.resolve(__dirname, '../..', TRACKS_FILE_NAME);
+const tracksFile = fileName || path.resolve(process.cwd(), getConfig().tracksFile);
 
 try {
   tracks = fs.readFileSync(tracksFile, 'utf8').toString().split('\n').defined().map(replaceDangers);


### PR DESCRIPTION
## Summary

Three-in-one before publishing to npm:

1. **`tracksFile` config knob** — `-f <file>` for \`music-utils-tracks-tag\` now has a config-driven default.
2. **Root README** — new \`/README.md\` intro-ing the monorepo with links to each package.
3. **music-utils README refresh** — expanded docs for \`tracks-tag\`, \`similarities\`, and \`sync-tracks\`.

## Config knob

Add top-level \`tracksFile\` to \`Config\` (default \`"tracks.txt"\`), parallel to \`libraryRoot\`. Consumed by \`music-utils-tracks-tag\`.

**Precedence:** CLI \`-f\` > \`config.tracksFile\` > default. Relative paths resolve against \`process.cwd()\`; absolute paths pass through.

**Drive-by bug fix:** the previous default in \`tag.tracks.ts\` was \`path.resolve(__dirname, '../..', TRACKS_FILE_NAME)\` — relative to the installed script location. Under \`npm install -g @hansogj/music-utils\` that would look inside the installed npm package directory instead of the user's music library. Now resolves against cwd.

## Root README

New \`/README.md\` at repo root with a table linking to each package's README (\`music-utils\`, \`discogs-item-lookup\`, \`discogs-cover\`), plus short **Development** and **Releases** sections covering pnpm workspace commands and Changesets.

## music-utils README refresh

- Add \`tracksFile\` to the config schema block and a per-key section explaining precedence.
- Expand **tracks-tag**: show both invocations (with/without \`-f\`), list the three-level resolution precedence, and describe the rip-then-tag flow that makes the default \"just work\".
- Rewrite **similarities**: what it does (fuzzy-match artist directory names across two library roots for duplicate detection), how it scans (\`-A\` one level deep, \`-B\` two levels deep), and full flag reference (\`-A -B -T -F --ignore -Q\`).
- Rewrite **sync-tracks**: clarify it's filename-only (tags aren't rewritten), and give the \"already tagged, filenames drifted\" use case.

## Test plan

- [x] \`pnpm run vitest\` — 331 passing (+1 new: config-file override of tracksFile)
- [x] Full \`pnpm precommit\` chain green across all 3 workspace packages (pre-commit hook)
- [x] Rendered both READMEs locally — links, code fences, tables all resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)