### PR TITLE
feat(rip): fetch Discogs cover art in parallel with cdparanoia

### DIFF
--- a/.changeset/rip-parallel-cover-fetch.md
+++ b/.changeset/rip-parallel-cover-fetch.md
@@ -1,0 +1,9 @@
+---
+"@hansogj/music-utils": patch
+---
+
+parallel cover-art fetch during `music-utils-rip`
+
+The Discogs cover fetch now starts as soon as we `chdir` into the album folder, in parallel with `cdparanoia`. Previously it was serialized after `cdparanoia` + WAV→FLAC + rename, which added seconds to the critical path for no reason (cover fetch is IO-bound on Discogs; the rip is IO-bound on the optical drive).
+
+Also fails soft: a Discogs error no longer aborts the rip. The error is logged and the rip continues — losing a 10-minute CD read to a transient Discogs blip is worse than shipping without a cover file.

--- a/packages/music-utils/src/run/rip.ts
+++ b/packages/music-utils/src/run/rip.ts
@@ -189,6 +189,11 @@ async function main({ releaseId, disc }: Pick<LookupReleaseOptions, 'disc' | 're
     chdir(fullPath);
     console.log(`   Current directory: ${process.cwd()}`);
 
+    console.log(`\n🖼️  Fetching album cover in background...`);
+    const coverPromise = coverFromDiscogs({ releaseId, quiet: true, token: process.env.DISCOGS_TOKEN ?? '' }).catch(
+      (err: unknown) => console.error('Cover fetch failed (rip continues):', err),
+    );
+
     try {
       await runCommand('cdparanoia', ['-B']);
     } catch (_error) {
@@ -204,8 +209,7 @@ async function main({ releaseId, disc }: Pick<LookupReleaseOptions, 'disc' | 're
     await convertWavFilesToFlac();
     await renameFlacFiles();
 
-    console.log(`\n🖼️  Fetching album cover... `);
-    await coverFromDiscogs({ releaseId, quiet: true, token: process.env.DISCOGS_TOKEN ?? '' });
+    await coverPromise;
 
     console.log('\n✏️  Tagging tracks...');
     const trackLines = readFileSync(path.resolve('../../tracks.txt'), 'utf8');


### PR DESCRIPTION
## Summary

Kick off the Discogs cover-art fetch in \`music-utils-rip\` as soon as we \`chdir\` into the album folder, then \`await\` its promise near the end. Previously the fetch was serialized after \`cdparanoia\` + WAV→FLAC + rename — the cover call is IO-bound on Discogs and the rip is IO-bound on the optical drive, so there was no reason to run them one after the other.

Also **fails soft**: a Discogs error no longer aborts the whole rip. The error is logged and the rest of the pipeline continues, since losing a 10-minute CD read to a transient Discogs blip is a worse outcome than shipping without a cover file.

## Changeset

Includes a \`patch\` changeset for \`@hansogj/music-utils\`. Feature is user-visible but the API surface is unchanged (\`music-utils-rip -r <id>\` still works identically), so a patch bump felt right — push back if you'd prefer minor.

## Test plan

- [x] Local \`pnpm run build\` clean
- [x] Verified locally via re-linked \`music-utils-rip\`
- [x] Full \`pnpm precommit\` chain green across all 3 workspace packages (pre-commit hook)

## Follow-ups (unrelated)

- \`NPM_TOKEN\` secret still needs to be added before the release workflow can auto-publish this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)