### PR TITLE
chore(ci): stop attempting npm publish in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,13 +31,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Create Release PR or publish
+      # No `publish` input: the action only manages the "Version Packages"
+      # PR (bumps versions, updates CHANGELOG, deletes consumed changesets).
+      # Actual `npm publish` is done manually from the maintainer's laptop
+      # for now:  cd packages/<pkg> && npm publish --access public
+      # Re-enable automated publish by putting the `publish: pnpm run release`
+      # input back and either setting `NPM_TOKEN` in repo secrets or wiring
+      # OIDC via npm Trusted Publisher.
+      - name: Create Release PR
         uses: changesets/action@v1
         with:
-          publish: pnpm run release
           version: pnpm run version-packages
           commit: 'chore: version packages'
           title: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The \`release\` workflow has been failing red on every merge to main since PR #70 because there's no working publish auth in place — either \`NPM_TOKEN\` was never persisted as a repo secret (last attempt via \`gh secret set\` didn't save; only \`DEPLOY_KEY\` is listed) or OIDC Trusted Publisher isn't configured yet.

Per user preference, move to **manual publish** for now. The workflow still opens the "Version Packages" PR (bumps versions, updates \`CHANGELOG.md\`, deletes consumed changesets) — it just doesn't try to \`npm publish\` afterward.

## Change

\`\`\`diff
-      - name: Create Release PR or publish
+      - name: Create Release PR
         uses: changesets/action@v1
         with:
-          publish: pnpm run release
           version: pnpm run version-packages
           commit: 'chore: version packages'
           title: 'chore: version packages'
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
\`\`\`

Also adds a comment block above the step documenting the manual publish flow and how to restore automated publish later.

## Manual publish flow (after this lands)

1. Merge a feature PR with a changeset.
2. Release workflow opens/updates the \"Version Packages\" PR (green ✅).
3. Merge the \"Version Packages\" PR → \`CHANGELOG.md\` and \`package.json\` versions land on main.
4. Locally: \`cd packages/music-utils && npm publish --access public\`

## Restore path

Set up **npm Trusted Publisher (OIDC)** (recommended — no token to manage, mandatory before Jan 2027 when npm restricts 2FA-bypassing tokens), then put \`publish: pnpm run release\` back. \`id-token: write\` permission is already in place.

Alternative: retry \`gh secret set NPM_TOKEN\` and put \`publish\` back the classic way.

## Test plan

- [x] YAML validates (workflow file syntactically clean)
- [x] Full \`pnpm precommit\` chain green across all 3 workspace packages (pre-commit hook)
- [x] Confirmed after merge: release run on \`main\` completes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)