### PR TITLE
chore(deps): patch medium + low Dependabot alerts (safe same-major bumps)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,12 @@ settings:
 
 overrides:
   flatted: ^3.4.2
+  brace-expansion@1: 1.1.13
+  brace-expansion@5: 5.0.6
+  picomatch@2: 2.3.2
+  picomatch@4: 4.0.4
+  js-yaml@4: 4.2.0
+  diff: 4.0.4
 
 importers:
 
@@ -1188,14 +1194,14 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.13:
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -1356,8 +1362,8 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
 
-  diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
@@ -1611,7 +1617,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: 4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -1982,8 +1988,8 @@ packages:
     resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -2277,12 +2283,12 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pidtree@1.0.0:
@@ -3132,7 +3138,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -3364,7 +3370,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -3925,7 +3931,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   arg@4.1.3: {}
 
@@ -4011,7 +4017,7 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -4020,7 +4026,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4175,7 +4181,7 @@ snapshots:
 
   detect-indent@6.1.0: {}
 
-  diff@4.0.2: {}
+  diff@4.0.4: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -4543,9 +4549,9 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -4926,7 +4932,7 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -5002,15 +5008,15 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.13
 
   minimatch@9.0.9:
     dependencies:
@@ -5144,7 +5150,7 @@ snapshots:
       ansi-styles: 6.2.3
       cross-spawn: 7.0.6
       memorystream: 0.3.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       pidtree: 1.0.0
       read-package-json-fast: 6.0.0
       shell-quote: 1.9.0
@@ -5274,9 +5280,9 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pidtree@1.0.0: {}
 
@@ -5343,7 +5349,7 @@ snapshots:
 
   readdirp@3.6.0:
     dependencies:
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   readdirp@4.1.2: {}
 
@@ -5657,8 +5663,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@1.1.1: {}
 
@@ -5722,7 +5728,7 @@ snapshots:
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
-      diff: 4.0.2
+      diff: 4.0.4
       make-error: 1.3.6
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
@@ -5740,7 +5746,7 @@ snapshots:
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
-      diff: 4.0.2
+      diff: 4.0.4
       make-error: 1.3.6
       typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
@@ -5942,8 +5948,8 @@ snapshots:
   vite@7.3.6(@types/node@25.5.0):
     dependencies:
       esbuild: 0.28.1
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.16
       rollup: 4.62.2
       tinyglobby: 0.2.15
@@ -5954,8 +5960,8 @@ snapshots:
   vite@7.3.6(@types/node@26.1.0):
     dependencies:
       esbuild: 0.28.1
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.16
       rollup: 4.62.2
       tinyglobby: 0.2.15
@@ -5978,7 +5984,7 @@ snapshots:
       expect-type: 1.4.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
@@ -6019,7 +6025,7 @@ snapshots:
       expect-type: 1.4.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
@@ -6059,7 +6065,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,24 @@ onlyBuiltDependencies:
   - '@vitest/coverage-v8'
 
 # Patch transitive vulnerabilities without waiting on upstream chains.
-# See GHSA advisories on `flatted` <3.4.2 (Prototype Pollution, DoS in parse).
-# Comes into the tree via eslint 10 -> file-entry-cache 8 -> flat-cache 4.0.1.
+# All entries below target open GHSA advisories on dev-time transitives.
+# Prefer same-major patches (safe); skip cross-major forces where the
+# exploit surface is nil (parsing our own YAML/build files, not attacker input).
 overrides:
+  # flatted <3.4.2: Prototype Pollution + DoS in parse().
+  # Via: eslint 10 -> file-entry-cache 8 -> flat-cache 4.0.1.
   flatted: '^3.4.2'
+  # brace-expansion 1.x <1.1.13: zero-step sequence hangs process.
+  # brace-expansion 5.x <5.0.6: numeric range defeats `max` DoS guard.
+  # Both come via eslint's minimatch chain; 2.x resolution is unaffected.
+  'brace-expansion@1': '1.1.13'
+  'brace-expansion@5': '5.0.6'
+  # picomatch 2.x <2.3.2 and 4.x <4.0.4: method injection in POSIX classes.
+  # Via tsc/eslint tinyglobby chains.
+  'picomatch@2': '2.3.2'
+  'picomatch@4': '4.0.4'
+  # js-yaml 4.x <4.2.0: quadratic DoS in merge-key handling.
+  # (3.x is separately advisory'd but requires cross-major upgrade — see backlog.)
+  'js-yaml@4': '4.2.0'
+  # diff <4.0.4: DoS in parsePatch/applyPatch. Via ts-node -> diff.
+  diff: '4.0.4'


### PR DESCRIPTION
## Summary

Follow-up to PR #82. Closes 5 of the 7 remaining Dependabot alerts via same-major pnpm overrides. Two alerts intentionally deferred; see the Deferred section below.

Same pattern as PR #82: dev-time transitives only, no consumer-facing tarball changes, no changeset.

## Alerts closed

| # | Severity | Package | From | To | Notes |
|---|----------|---------|------|-----|-------|
| #36 | Medium | \`brace-expansion@1\` | 1.1.12 | 1.1.13 | zero-step sequence hang |
| #38 | Medium | \`brace-expansion@5\` | 5.0.5 | 5.0.6 | numeric range defeats \`max\` DoS guard |
| #24 | Medium | \`picomatch@2\` | 2.3.1 | 2.3.2 | POSIX class method injection |
| #26 | Medium | \`picomatch@4\` | 4.0.3 | 4.0.4 | POSIX class method injection |
| #44 | Medium | \`js-yaml@4\` | 4.1.1 | 4.2.0 | quadratic DoS in merge-key handling |
| #6  | Low    | \`diff\` | 4.0.2 | 4.0.4 | DoS in parsePatch / applyPatch (jsdiff) |

## Deferred (with reasoning)

- **\`esbuild@0.27.7\`** (Low, #49 — Windows dev-server file read). Via \`tsup@8.5.1\`. Fix requires 0.27 → 0.28 which is effectively a major bump in esbuild's versioning (0.x minor bumps introduce breaking changes). Not worth risking a tsup build regression for a Windows-only dev-server advisory that never touches production.
- **\`js-yaml@3.15.0\`** (Medium, partial of #44 — quadratic DoS). Via \`read-yaml-file@1.1.0\`. Fix requires 3 → 4 which removes \`safeLoad\`/\`safeDump\` APIs; \`read-yaml-file\` is unmaintained and doesn't have an update path. Parses our own build files, not attacker-controlled input.

Both deferrals are captured in the project backlog for reconsideration if either resurfaces as a real risk.

## Change

Extends \`pnpm-workspace.yaml\`'s existing \`overrides\` block (from PR #82's \`flatted\` fix) with narrow same-major version pins. In-file comments explain each entry's advisory and dependency chain.

## Verification

- \`pnpm -r --sequential --if-present run test\` — all green (18 + 19 + 337 tests + 4 CI integration runs)
- Lockfile grep confirms every closed alert's vulnerable version is gone

## What remains

After this lands, the security dashboard should show only the two deferred alerts as open. If either becomes actionable (e.g. tsup ships esbuild 0.29+, or an alternative to \`read-yaml-file\` emerges), we can knock them out then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)