### PR TITLE
fix(rip): stop asking "Is this right info?" twice per disc

### DIFF
--- a/.changeset/rip-dedupe-confirmation.md
+++ b/.changeset/rip-dedupe-confirmation.md
@@ -1,0 +1,9 @@
+---
+"@hansogj/music-utils": patch
+---
+
+fix: `music-utils-rip` no longer asks "Is this right info? Y/N?" twice
+
+The rip flow was prompting for confirmation once after the Discogs lookup and again inside `tagAlbum` (which does its own `parseAlbumInfo` + `albumPrompt`). Rippers had to say "yes" twice for every disc.
+
+Fix: `tagAlbum` now accepts an optional pre-confirmed `Release` as its third argument. When supplied, it skips the internal path parsing and prompt entirely. `music-utils-rip` passes the already-confirmed `safeRelease` through, so the second prompt is skipped. The other four callers of `tagAlbum` (`bulk.tag.album`, `tag.album`, `tag.cover.album`, `tag.tracks`) don't pass the arg, so their behavior is unchanged.

--- a/packages/music-utils/src/album/album.test.ts
+++ b/packages/music-utils/src/album/album.test.ts
@@ -43,6 +43,17 @@ describe('tag album', () => {
       });
     });
 
+    describe('when preConfirmedRelease is supplied (rip flow)', () => {
+      beforeEach(async () => {
+        mocks.readDir.mockReturnValue([]);
+        await tagAlbum(mockDirName, undefined, release);
+      });
+      it('skips both parseAlbumInfo and albumPrompt', () => {
+        expect(mocks.parseAlbumInfo).not.toHaveBeenCalled();
+        expect(mocks.albumPrompt).not.toHaveBeenCalled();
+      });
+    });
+
     describe('with response from prompt', () => {
       const extractedTagsDefault: Partial<Track> = {
         album: 'MDK',

--- a/packages/music-utils/src/album/album.ts
+++ b/packages/music-utils/src/album/album.ts
@@ -23,10 +23,15 @@ export const extractAlbumInfo = async (dirName: string): Promise<File[]> => {
   return files.filter((file) => MusicFileTypes.includes(file.fileType));
 };
 
-export const tagAlbum = async (dirName: string, tracksFromFile?: string[]): Promise<ReleaseFiles> => {
+export const tagAlbum = async (
+  dirName: string,
+  tracksFromFile?: string[],
+  preConfirmedRelease?: Partial<Release>,
+): Promise<ReleaseFiles> => {
   const { tagOnly } = getCommandLineArgs();
 
-  const release = tagOnly ? parseAlbumInfo(dirName) : await albumPrompt(parseAlbumInfo(dirName));
+  const release =
+    preConfirmedRelease ?? (tagOnly ? parseAlbumInfo(dirName) : await albumPrompt(parseAlbumInfo(dirName)));
 
   const extracted = await extractAlbumInfo(dirName);
   const merged = mergeMetaData(extracted, release, tracksFromFile);

--- a/packages/music-utils/src/run/rip.ts
+++ b/packages/music-utils/src/run/rip.ts
@@ -214,7 +214,7 @@ async function main({ releaseId, disc }: Pick<LookupReleaseOptions, 'disc' | 're
     console.log('\n✏️  Tagging tracks...');
     const trackLines = readFileSync(path.resolve('../../tracks.txt'), 'utf8');
     const tracks = trackLines.split('\n').defined().map(replaceDangers);
-    const { files, release: taggedRelease } = await tagAlbum(process.cwd(), tracks);
+    const { files, release: taggedRelease } = await tagAlbum(process.cwd(), tracks, safeRelease);
     await syncTrackNames(files, taggedRelease as Release);
 
     console.log(`\n🔀 Returning to starting directory: ${initialDir}`);


### PR DESCRIPTION
## Summary

Rip flow was prompting for release-info confirmation **twice** per disc:

1. `rip.ts:170` — right after the Discogs lookup, to confirm the release metadata
2. `rip.ts:217` — indirectly, because `tagAlbum` ran its own `parseAlbumInfo` + `albumPrompt`

Users had to say "yes" twice for every rip. Backlog item you added on 2026-07-16.

## Fix

Add an optional third argument to `tagAlbum`:

\`\`\`diff
-export const tagAlbum = async (dirName: string, tracksFromFile?: string[]): Promise<ReleaseFiles> => {
+export const tagAlbum = async (
+  dirName: string,
+  tracksFromFile?: string[],
+  preConfirmedRelease?: Partial<Release>,
+): Promise<ReleaseFiles> => {
   const { tagOnly } = getCommandLineArgs();
-  const release = tagOnly ? parseAlbumInfo(dirName) : await albumPrompt(parseAlbumInfo(dirName));
+  const release =
+    preConfirmedRelease ?? (tagOnly ? parseAlbumInfo(dirName) : await albumPrompt(parseAlbumInfo(dirName)));
\`\`\`

When supplied, `tagAlbum` skips its internal path parsing and prompt entirely.

\`music-utils-rip\` passes its already-confirmed \`safeRelease\` through:

\`\`\`diff
-    const { files, release: taggedRelease } = await tagAlbum(process.cwd(), tracks);
+    const { files, release: taggedRelease } = await tagAlbum(process.cwd(), tracks, safeRelease);
\`\`\`

The other four callers (\`bulk.tag.album\`, \`tag.album\`, \`tag.cover.album\`, \`tag.tracks\`) don't pass the arg, so their behavior is unchanged.

## Test plan

- [x] New test in \`album.test.ts\` covering the pre-confirmed path: asserts both \`parseAlbumInfo\` and \`albumPrompt\` are skipped when the third arg is supplied
- [x] \`pnpm run vitest\` — 338 passing (+1)
- [x] Full \`pnpm precommit\` chain green (pre-commit hook)

## Changeset

Patch bump — user-visible behavior change (one fewer prompt), no API breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)