### PR TITLE
feat(config): Tier 2 knobs — cover.filename, disc.separator, flac.compressionLevel

### DIFF
--- a/.changeset/config-tier2-cover-disc-flac.md
+++ b/.changeset/config-tier2-cover-disc-flac.md
@@ -1,0 +1,15 @@
+---
+"@hansogj/music-utils": minor
+---
+
+feat: three new config knobs — `cover.filename`, `disc.separator`, `flac.compressionLevel`
+
+Tier 2 of the config work started in PR #72. Three new keys:
+
+- **`cover.filename`** (default `"cover.jpg"`) — filename `music-utils-rip` and `music-utils-cover-photo` write for album art. Set to `"folder.jpg"` for the Windows convention, `"AlbumArt.jpg"` for other players.
+- **`disc.separator`** (default `"∕"` U+2215) — character between disc-number and total in multi-disc folder names (`Disc 1∕2`). Cannot be `/` (filesystem restriction). Common alternates: `-`, `_`. Also used when sanitizing strings containing `/` in tags/tracklists.
+- **`flac.compressionLevel`** (default `5`, range `0`–`8`) — passed to the `flac` CLI as `-<level>` during the WAV→FLAC conversion step in `music-utils-rip`.
+
+`patterns.discSuffix` gained a `{discSep}` token so overriding `disc.separator` also flows through the default suffix without also having to override the pattern.
+
+Housekeeping: removed the unused `COVER_FILE_RESOLUTION = 600` constant. It was declared but never plumbed into `discogs-cover`'s API (which doesn't accept a resolution parameter).

--- a/packages/music-utils/README.md
+++ b/packages/music-utils/README.md
@@ -67,12 +67,21 @@ Every key is optional; anything you omit falls back to the default.
     "track": "{trackNo}{artistPrefix}{title}",
     "trackMultiDisc": "d{disc}t{trackNo}.{artistPrefix}{title}",
     "artistPrefix": " {artist} - ",
-    "discSuffix": " (Disc {disc}∕{total})",
+    "discSuffix": " (Disc {disc}{discSep}{total})",
     "auxSuffix": " [{aux}]"
   },
   "artist": {
     "sortArticles": true,
     "articles": ["the", "los", "il", "la", "el", "le"]
+  },
+  "cover": {
+    "filename": "cover.jpg"
+  },
+  "disc": {
+    "separator": "∕"
+  },
+  "flac": {
+    "compressionLevel": 5
   }
 }
 ```
@@ -87,17 +96,31 @@ Default path used by `music-utils-tracks-tag` when `-f` is not supplied. Relativ
 
 ### `patterns.*`
 
-Templates use `{token}` substitution. Available tokens: `{artist}`, `{album}`, `{year}`, `{disc}`, `{total}`, `{trackNo}`, `{title}`, `{aux}`, `{discSuffix}`, `{auxSuffix}`, `{artistPrefix}`. Missing tokens resolve to empty and surrounding whitespace collapses.
+Templates use `{token}` substitution. Available tokens: `{artist}`, `{album}`, `{year}`, `{disc}`, `{total}`, `{trackNo}`, `{title}`, `{aux}`, `{discSep}`, `{discSuffix}`, `{auxSuffix}`, `{artistPrefix}`. Missing tokens resolve to empty and surrounding whitespace collapses.
 
 - `artistFolder` / `albumFolder` — the two path segments `music-utils-*` writes into.
 - `track` / `trackMultiDisc` — filename (without extension) for single-disc vs multi-disc releases.
 - `artistPrefix` — inserted before `{title}` when the release has an artist; renders to `' '` otherwise.
-- `discSuffix` — appended to `albumFolder` when `noOfDiscs > 1`. Note: the character between disc/total is `∕` (U+2215 division slash), not `/`, because filesystems reject `/` in path segments.
+- `discSuffix` — appended to `albumFolder` when `noOfDiscs > 1`. Includes a `{discSep}` token which resolves to `disc.separator` at render time.
 - `auxSuffix` — appended when the album has aux info (e.g. `[remaster]`).
 
 ### `artist.sortArticles` / `artist.articles`
 
 When `true`, definite articles listed in `articles` move to the end during folder naming: `"The Beatles" → "Beatles, The"`. Set `false` to keep the article in place, or replace `articles` with your own list.
+
+### `cover.filename`
+
+Filename `music-utils-rip` and `music-utils-cover-photo` write for album art. Default `"cover.jpg"`. Change to `"folder.jpg"` for the Windows convention, or `"AlbumArt.jpg"` if that's what your player expects.
+
+### `disc.separator`
+
+Character inserted between disc-number and total in multi-disc folder names, e.g. `Disc 1∕2`. Default is `∕` (U+2215 division slash). It **cannot be `/`** — filesystems reject that character in path segments. Common alternates: `-`, `_`, or a full-width `／`. Also used when sanitizing user-supplied strings that contain `/` (via `replaceDangers`).
+
+Changing this after your library already contains multi-disc folders means old folders parse under the old separator and new folders use the new one — safest to pick a value at library setup and leave it alone.
+
+### `flac.compressionLevel`
+
+Passed to the `flac` CLI as `-<level>` during `music-utils-rip`'s WAV→FLAC step. Range `0` (fast/large) through `8` (slow/small). Default `5` matches the `flac` CLI's own default.
 
 # Features
 

--- a/packages/music-utils/src/album/parse.path.ts
+++ b/packages/music-utils/src/album/parse.path.ts
@@ -3,7 +3,6 @@ import maybe from '@hansogj/maybe';
 import path from 'path';
 
 import { getConfig } from '../config';
-import { DISC_NO_SPLIT } from '../constants';
 import { applyMatch, Parser, regExp } from '../tag/parser';
 import { Release } from '../types';
 import { getCommandLineArgs } from '../utils/cmd.options';
@@ -26,7 +25,7 @@ const cleanAuxInfo = (...aux: string[]) => removeDoubleSpace(aux.join(' ')).repl
 
 const splitParsedDiscNumber = (parsedDiscNumber: string): string[] => {
   const parts = `${parsedDiscNumber}`
-    .split(DISC_NO_SPLIT)
+    .split(getConfig().disc.separator)
     .map((n: string) => toIntOr(n, undefined))
     .defined()
     .map((e) => `${e}`);

--- a/packages/music-utils/src/config/defaults.ts
+++ b/packages/music-utils/src/config/defaults.ts
@@ -1,4 +1,4 @@
-import { DISC_LABEL, DISC_NO_SPLIT, TRACKS_FILE_NAME } from '../constants';
+import { COVER_FILE_NAME, DISC_LABEL, DISC_NO_SPLIT, TRACKS_FILE_NAME } from '../constants';
 import type { Config } from './schema';
 
 export const DEFAULT_CONFIG: Config = {
@@ -9,11 +9,21 @@ export const DEFAULT_CONFIG: Config = {
     track: '{trackNo}{artistPrefix}{title}',
     trackMultiDisc: 'd{disc}t{trackNo}.{artistPrefix}{title}',
     artistPrefix: ' {artist} - ',
-    discSuffix: ` (${DISC_LABEL} {disc}${DISC_NO_SPLIT}{total})`,
+    // {discSep} resolves from `config.disc.separator` at render time.
+    discSuffix: ` (${DISC_LABEL} {disc}{discSep}{total})`,
     auxSuffix: ' [{aux}]',
   },
   artist: {
     sortArticles: true,
     articles: ['the', 'los', 'il', 'la', 'el', 'le'],
+  },
+  cover: {
+    filename: COVER_FILE_NAME,
+  },
+  disc: {
+    separator: DISC_NO_SPLIT,
+  },
+  flac: {
+    compressionLevel: 5,
   },
 };

--- a/packages/music-utils/src/config/load.test.ts
+++ b/packages/music-utils/src/config/load.test.ts
@@ -22,12 +22,32 @@ describe('loadConfig', () => {
     expect(cfg.artist.sortArticles).toBe(true);
     expect(cfg.libraryRoot).toBeUndefined();
     expect(cfg.tracksFile).toBe(DEFAULT_CONFIG.tracksFile);
+    expect(cfg.cover.filename).toBe('cover.jpg');
+    expect(cfg.disc.separator).toBe('∕');
+    expect(cfg.flac.compressionLevel).toBe(5);
   });
 
   it('overrides tracksFile from config file', () => {
     writeFileSync(join(tempDir, 'music-utils.config.json'), JSON.stringify({ tracksFile: 'my.tracks.txt' }));
     const cfg = loadConfig(tempDir);
     expect(cfg.tracksFile).toBe('my.tracks.txt');
+  });
+
+  it('merges cover/disc/flac partially without dropping other keys', () => {
+    writeFileSync(
+      join(tempDir, 'music-utils.config.json'),
+      JSON.stringify({
+        cover: { filename: 'folder.jpg' },
+        disc: { separator: '-' },
+        flac: { compressionLevel: 8 },
+      }),
+    );
+    const cfg = loadConfig(tempDir);
+    expect(cfg.cover.filename).toBe('folder.jpg');
+    expect(cfg.disc.separator).toBe('-');
+    expect(cfg.flac.compressionLevel).toBe(8);
+    // Untouched:
+    expect(cfg.artist.sortArticles).toBe(true);
   });
 
   it('picks up ./music-utils.config.json in cwd', () => {

--- a/packages/music-utils/src/config/load.ts
+++ b/packages/music-utils/src/config/load.ts
@@ -26,6 +26,9 @@ const merge = (base: Config, override: PartialConfig | null): Config => {
       sortArticles: override.artist?.sortArticles ?? base.artist.sortArticles,
       articles: override.artist?.articles ?? base.artist.articles,
     },
+    cover: { ...base.cover, ...(override.cover ?? {}) },
+    disc: { ...base.disc, ...(override.disc ?? {}) },
+    flac: { ...base.flac, ...(override.flac ?? {}) },
   };
 };
 

--- a/packages/music-utils/src/config/render.test.ts
+++ b/packages/music-utils/src/config/render.test.ts
@@ -47,6 +47,11 @@ describe('renderAlbumFolder', () => {
     };
     expect(renderAlbumFolder(release, cfg)).toBe('IV - 1971');
   });
+
+  it('honors an overridden disc.separator via the {discSep} token', () => {
+    const cfg: Config = { ...DEFAULT_CONFIG, disc: { separator: '-' } };
+    expect(renderAlbumFolder({ ...release, discNumber: '1', noOfDiscs: '2' }, cfg)).toBe(`1971 IV (${DISC_LABEL} 1-2)`);
+  });
 });
 
 describe('renderArtistFolder', () => {

--- a/packages/music-utils/src/config/render.ts
+++ b/packages/music-utils/src/config/render.ts
@@ -14,7 +14,11 @@ const isMultiDisc = (release: Partial<Release>): boolean => {
 export const renderAlbumFolder = (release: Partial<Release>, config: Config): string => {
   const { patterns } = config;
   const discSuffix = isMultiDisc(release)
-    ? renderTemplate(patterns.discSuffix, { disc: release.discNumber, total: release.noOfDiscs })
+    ? renderTemplate(patterns.discSuffix, {
+        disc: release.discNumber,
+        total: release.noOfDiscs,
+        discSep: config.disc.separator,
+      })
     : '';
   const auxSuffix = release.aux ? renderTemplate(patterns.auxSuffix, { aux: release.aux }) : '';
   return renderTemplate(patterns.albumFolder, {

--- a/packages/music-utils/src/config/schema.ts
+++ b/packages/music-utils/src/config/schema.ts
@@ -25,6 +25,22 @@ export interface Config {
     /** Which words to treat as definite articles for the sort. */
     articles: string[];
   };
+  cover: {
+    /** Filename `music-utils-rip` / `music-utils-cover-photo` write for album art (default: "cover.jpg"). */
+    filename: string;
+  };
+  disc: {
+    /**
+     * Character between disc-number and total in folder names (default: `∕` U+2215).
+     * Cannot be `/` (filesystem restriction). Applied to both `patterns.discSuffix`
+     * (via `{discSep}` token) and `replaceDangers` when sanitizing user-supplied strings.
+     */
+    separator: string;
+  };
+  flac: {
+    /** Passed to the `flac` CLI as `-<level>`. Range 0–8; higher = smaller file, slower encode. Default: 5. */
+    compressionLevel: number;
+  };
 }
 
 export type PartialConfig = {
@@ -32,4 +48,7 @@ export type PartialConfig = {
   tracksFile?: string;
   patterns?: Partial<Config['patterns']>;
   artist?: Partial<Config['artist']>;
+  cover?: Partial<Config['cover']>;
+  disc?: Partial<Config['disc']>;
+  flac?: Partial<Config['flac']>;
 };

--- a/packages/music-utils/src/constants.ts
+++ b/packages/music-utils/src/constants.ts
@@ -2,7 +2,6 @@ export const ACUTE = '´';
 export const DISC_NO_SPLIT = '∕'; //  '::';
 export const TRACKS_FILE_NAME = 'tracks.txt';
 export const COVER_FILE_NAME = 'cover.jpg';
-export const COVER_FILE_RESOLUTION = 600;
 export const DISC_LABEL = 'Disc';
 export const DEFINITE_ARTICLES = ['the', 'los', 'il', 'la', 'el', 'le'];
 export const BLACK_LIST_SIMILAR_WORD = DEFINITE_ARTICLES.concat([

--- a/packages/music-utils/src/covers/photo.ts
+++ b/packages/music-utils/src/covers/photo.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import { discogsMainCover } from '@hansogj/discogs-cover';
 
 import { parseAlbumInfo } from '../album/parse.path';
-import { COVER_FILE_NAME } from '../constants';
+import { getConfig } from '../config';
 import { Release } from '../types';
 import { error, info, success } from '../utils/color.log';
 import { albumPrompt } from '../utils/prompt';
@@ -48,7 +48,7 @@ export const coverFromDiscogs = async ({
       });
     }
 
-    fs.writeFileSync(COVER_FILE_NAME, imageBuffer);
+    fs.writeFileSync(getConfig().cover.filename, imageBuffer);
     info('Cover saved!');
   } catch (e) {
     error((e as Error).message);

--- a/packages/music-utils/src/run/rip.ts
+++ b/packages/music-utils/src/run/rip.ts
@@ -117,7 +117,7 @@ async function convertWavFilesToFlac(): Promise<void> {
         console.log(`🗑️  Removing pre-gap or empty file (duration: ${duration}s): ${wavFile}`);
         await rm(wavFile);
       } else {
-        await runCommand('flac', ['--keep-foreign-metadata', wavFile]);
+        await runCommand('flac', [`-${getConfig().flac.compressionLevel}`, '--keep-foreign-metadata', wavFile]);
         await rm(wavFile);
       }
     } catch (error) {

--- a/packages/music-utils/src/utils/path.ts
+++ b/packages/music-utils/src/utils/path.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
 
-import { DISC_NO_SPLIT } from '../constants';
+import { getConfig } from '../config';
 import { singleSpace } from '../tag/parser';
 import { FILETYPE } from '../types';
 import { executeFile } from './execute';
@@ -37,4 +37,4 @@ export const renameFile = (src: string, target: string) => executeFile('mv', [sr
 
 export const replaceQuotes = (str = '') => singleSpace(str).replace(/"/g, `'`);
 
-export const replaceDangers = (str = '') => replaceQuotes(str).replace(/\//g, DISC_NO_SPLIT);
+export const replaceDangers = (str = '') => replaceQuotes(str).replace(/\//g, getConfig().disc.separator);


### PR DESCRIPTION
## Summary

Three new user-facing config knobs. Continues the Tier 1 work from PR #72 and PR #76.

| Key | Default | Purpose |
|-----|---------|---------|
| \`cover.filename\` | \`"cover.jpg"\` | Filename \`music-utils-rip\` / \`music-utils-cover-photo\` write for album art. Set to \`"folder.jpg"\` for Windows convention. |
| \`disc.separator\` | \`"∕"\` (U+2215) | Character between disc-number and total in multi-disc folder names (\`Disc 1∕2\`). Cannot be \`/\` (filesystem restriction). |
| \`flac.compressionLevel\` | \`5\` (range 0–8) | Passed to the \`flac\` CLI as \`-<level>\` during \`music-utils-rip\`'s WAV→FLAC step. |

## Renderer change

\`patterns.discSuffix\` default template swaps a hardcoded \`∕\` for a \`{discSep}\` token that resolves from \`config.disc.separator\` at render time. Users who override \`disc.separator\` in their config file now also get that separator in the default \`discSuffix\` — no need to override both.

## Cleanup

Removes \`COVER_FILE_RESOLUTION = 600\` from \`constants.ts\`. It was declared but never plumbed into \`discogs-cover\`'s API (which has no resolution parameter). Aspirational dead code from way back.

## Test plan

- [x] \`pnpm run vitest\` — 340 passing (+2 new: \`disc.separator\` override via \`{discSep}\` token, and cover/disc/flac merge in \`loadConfig\`)
- [x] Full \`pnpm precommit\` chain green

## Follow-ups on the backlog after this

Remaining active items: dedupe rip prompt (done), zsh/fish completion, \`constants.ts\` cleanup (\`DEFINITE_ARTICLES\`), validate \`noOfDiscs >= discNumber\`, zod evaluation, OIDC Trusted Publisher.

## Changeset

Minor bump — three new user-visible knobs, no breaking API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)