### PR TITLE
feat(config): validate types + ranges at load time (no new runtime dep)

### DIFF
--- a/.changeset/config-validate.md
+++ b/.changeset/config-validate.md
@@ -1,0 +1,16 @@
+---
+"@hansogj/music-utils": patch
+---
+
+fix: validate config file types + ranges at load time
+
+`loadConfig` now runs a schema check after merging. Bad values in your `music-utils.config.json` or `~/.music-utilsrc.json` throw a `ConfigError` naming the offending path (e.g. `"flac.compressionLevel: expected 0–8, got 9"`) instead of silently passing through to a `flac` invocation, `parseInt`, or a template renderer.
+
+Checks:
+- All string keys are strings (`tracksFile`, `patterns.*`, `cover.filename`, `disc.separator`).
+- `libraryRoot` is a string or `undefined`.
+- `artist.sortArticles` is a boolean; `artist.articles` is a string array.
+- `flac.compressionLevel` is an integer in `0..8`.
+- `disc.separator` is non-empty and doesn't contain `/`.
+
+Behavior for valid configs (including the default) is unchanged. `ConfigError` and `validateConfig` are now exported from `@hansogj/music-utils/build/config` if you want to run the check yourself.

--- a/packages/music-utils/README.md
+++ b/packages/music-utils/README.md
@@ -53,7 +53,7 @@ Folder naming, track filenames, and the library root are configurable via a JSON
 2. `~/.music-utilsrc.json` in your home directory (user-global)
 3. Built-in defaults
 
-Every key is optional; anything you omit falls back to the default.
+Every key is optional; anything you omit falls back to the default. Types and ranges are checked at load time — a bad value (e.g. `flac.compressionLevel: "banana"` or `disc.separator: "a/b"`) throws a `ConfigError` naming the offending path so you can fix it, rather than silently corrupting a rip.
 
 ## Schema
 

--- a/packages/music-utils/src/config/index.ts
+++ b/packages/music-utils/src/config/index.ts
@@ -3,3 +3,4 @@ export { loadConfig } from './load';
 export { renderAlbumFolder, renderArtistFolder, renderTemplate, renderTrackName } from './render';
 export type { Config, PartialConfig } from './schema';
 export { getConfig, resetConfigCache } from './singleton';
+export { ConfigError, validateConfig } from './validate';

--- a/packages/music-utils/src/config/load.test.ts
+++ b/packages/music-utils/src/config/load.test.ts
@@ -33,6 +33,11 @@ describe('loadConfig', () => {
     expect(cfg.tracksFile).toBe('my.tracks.txt');
   });
 
+  it('throws ConfigError when a value has the wrong type', () => {
+    writeFileSync(join(tempDir, 'music-utils.config.json'), JSON.stringify({ flac: { compressionLevel: 'banana' } }));
+    expect(() => loadConfig(tempDir)).toThrow(/flac\.compressionLevel/);
+  });
+
   it('merges cover/disc/flac partially without dropping other keys', () => {
     writeFileSync(
       join(tempDir, 'music-utils.config.json'),

--- a/packages/music-utils/src/config/load.ts
+++ b/packages/music-utils/src/config/load.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 
 import { DEFAULT_CONFIG } from './defaults';
 import type { Config, PartialConfig } from './schema';
+import { validateConfig } from './validate';
 
 const CONFIG_FILE_NAME = 'music-utils.config.json';
 const HOME_CONFIG_FILE_NAME = '.music-utilsrc.json';
@@ -45,5 +46,7 @@ export const loadConfig = (cwd: string = process.cwd()): Config => {
   const home = readIfExists(resolve(homedir(), HOME_CONFIG_FILE_NAME));
   const project = readIfExists(resolve(cwd, CONFIG_FILE_NAME));
   const merged = merge(merge(DEFAULT_CONFIG, home), project);
-  return merged.libraryRoot ? { ...merged, libraryRoot: expandHome(merged.libraryRoot) } : merged;
+  const resolved = merged.libraryRoot ? { ...merged, libraryRoot: expandHome(merged.libraryRoot) } : merged;
+  validateConfig(resolved);
+  return resolved;
 };

--- a/packages/music-utils/src/config/validate.test.ts
+++ b/packages/music-utils/src/config/validate.test.ts
@@ -1,0 +1,83 @@
+import { DEFAULT_CONFIG } from './defaults';
+import type { Config } from './schema';
+import { ConfigError, validateConfig } from './validate';
+
+const cloneDefault = (): Config => JSON.parse(JSON.stringify(DEFAULT_CONFIG)) as Config;
+
+describe('validateConfig', () => {
+  it('accepts the default config', () => {
+    expect(() => validateConfig(DEFAULT_CONFIG)).not.toThrow();
+  });
+
+  it('accepts libraryRoot: undefined', () => {
+    const cfg = cloneDefault();
+    delete cfg.libraryRoot;
+    expect(() => validateConfig(cfg)).not.toThrow();
+  });
+
+  describe('type errors', () => {
+    it('rejects non-string tracksFile', () => {
+      const cfg = { ...cloneDefault(), tracksFile: 42 as unknown as string };
+      expect(() => validateConfig(cfg)).toThrow(ConfigError);
+      expect(() => validateConfig(cfg)).toThrow(/tracksFile/);
+    });
+
+    it('rejects non-string pattern', () => {
+      const cfg = cloneDefault();
+      (cfg.patterns as unknown as Record<string, unknown>).albumFolder = null;
+      expect(() => validateConfig(cfg)).toThrow(/patterns\.albumFolder/);
+    });
+
+    it('rejects non-boolean sortArticles', () => {
+      const cfg = cloneDefault();
+      (cfg.artist as unknown as Record<string, unknown>).sortArticles = 'yes';
+      expect(() => validateConfig(cfg)).toThrow(/artist\.sortArticles/);
+    });
+
+    it('rejects non-array articles', () => {
+      const cfg = cloneDefault();
+      (cfg.artist as unknown as Record<string, unknown>).articles = 'the';
+      expect(() => validateConfig(cfg)).toThrow(/artist\.articles/);
+    });
+  });
+
+  describe('disc.separator', () => {
+    it('rejects empty string', () => {
+      const cfg = { ...cloneDefault(), disc: { separator: '' } };
+      expect(() => validateConfig(cfg)).toThrow(/disc\.separator.*non-empty/);
+    });
+
+    it('rejects a value containing "/"', () => {
+      const cfg = { ...cloneDefault(), disc: { separator: 'a/b' } };
+      expect(() => validateConfig(cfg)).toThrow(/disc\.separator.*"\/"/);
+    });
+
+    it('accepts a plain hyphen', () => {
+      const cfg = { ...cloneDefault(), disc: { separator: '-' } };
+      expect(() => validateConfig(cfg)).not.toThrow();
+    });
+  });
+
+  describe('flac.compressionLevel', () => {
+    it('rejects a string like "banana"', () => {
+      const cfg = cloneDefault();
+      (cfg.flac as unknown as Record<string, unknown>).compressionLevel = 'banana';
+      expect(() => validateConfig(cfg)).toThrow(/flac\.compressionLevel.*integer/);
+    });
+
+    it('rejects out-of-range values', () => {
+      expect(() => validateConfig({ ...cloneDefault(), flac: { compressionLevel: -1 } })).toThrow(/0–8/);
+      expect(() => validateConfig({ ...cloneDefault(), flac: { compressionLevel: 9 } })).toThrow(/0–8/);
+    });
+
+    it('rejects non-integer numbers', () => {
+      expect(() => validateConfig({ ...cloneDefault(), flac: { compressionLevel: 5.5 } })).toThrow(/integer/);
+    });
+
+    it('accepts 0 through 8', () => {
+      for (let i = 0; i <= 8; i += 1) {
+        expect(() => validateConfig({ ...cloneDefault(), flac: { compressionLevel: i } })).not.toThrow();
+      }
+    });
+  });
+});

--- a/packages/music-utils/src/config/validate.ts
+++ b/packages/music-utils/src/config/validate.ts
@@ -1,0 +1,62 @@
+import type { Config } from './schema';
+
+/**
+ * Thrown when a loaded config fails validation.
+ * `.path` is a dotted key path (e.g. `"flac.compressionLevel"`) for the offending value.
+ */
+export class ConfigError extends Error {
+  constructor(
+    public readonly path: string,
+    message: string,
+  ) {
+    super(`${path}: ${message}`);
+    this.name = 'ConfigError';
+  }
+}
+
+const isString = (v: unknown): v is string => typeof v === 'string';
+const isBoolean = (v: unknown): v is boolean => typeof v === 'boolean';
+const isStringArray = (v: unknown): v is string[] => Array.isArray(v) && v.every(isString);
+const isInt = (v: unknown): v is number => typeof v === 'number' && Number.isInteger(v);
+
+const requireString = (v: unknown, path: string): void => {
+  if (!isString(v)) throw new ConfigError(path, `expected string, got ${typeof v}`);
+};
+
+const requireIntInRange = (v: unknown, path: string, min: number, max: number): void => {
+  if (!isInt(v)) throw new ConfigError(path, `expected integer, got ${typeof v}`);
+  if (v < min || v > max) throw new ConfigError(path, `expected ${min}–${max}, got ${v}`);
+};
+
+/** Assert the loaded config is well-formed. Throws `ConfigError` on the first violation. */
+export const validateConfig = (cfg: Config): void => {
+  if (cfg.libraryRoot !== undefined && !isString(cfg.libraryRoot)) {
+    throw new ConfigError('libraryRoot', `expected string or undefined, got ${typeof cfg.libraryRoot}`);
+  }
+
+  requireString(cfg.tracksFile, 'tracksFile');
+
+  const patternKeys: (keyof Config['patterns'])[] = [
+    'artistFolder',
+    'albumFolder',
+    'track',
+    'trackMultiDisc',
+    'artistPrefix',
+    'discSuffix',
+    'auxSuffix',
+  ];
+  patternKeys.forEach((k) => requireString(cfg.patterns?.[k], `patterns.${k}`));
+
+  if (!isBoolean(cfg.artist?.sortArticles))
+    throw new ConfigError('artist.sortArticles', `expected boolean, got ${typeof cfg.artist?.sortArticles}`);
+  if (!isStringArray(cfg.artist?.articles)) throw new ConfigError('artist.articles', `expected array of strings`);
+
+  requireString(cfg.cover?.filename, 'cover.filename');
+
+  requireString(cfg.disc?.separator, 'disc.separator');
+  if (cfg.disc.separator.length === 0) throw new ConfigError('disc.separator', 'must be non-empty');
+  if (cfg.disc.separator.includes('/'))
+    throw new ConfigError('disc.separator', 'cannot contain "/" (filesystem restriction)');
+
+  requireIntInRange(cfg.flac?.compressionLevel, 'flac.compressionLevel', 0, 8);
+};


### PR DESCRIPTION
## Summary

Backlog item #4 (Zod evaluation) — resolved as **hand-rolled validator, no new dep**.

Adds a small validator that runs inside \`loadConfig\` after the merge. Bad values now throw a \`ConfigError\` naming the offending dotted path (e.g. \`"flac.compressionLevel: expected 0–8, got 9"\`), instead of silently passing through to \`flac -banana\`, \`parseInt('banana')\`, or a template renderer that produces nonsense.

## Why not zod / yup / joi?

Evaluated all three surfaces (config file, CLI params, Discogs API). The config file is the highest silent-corruption risk; CLI params are already coerced; prompts already have inline validation; Discogs drift is rare and its failure mode is loud enough. At this project's scale, a ~50-line hand-rolled validator without an added dependency wins over a full schema-lib adoption — captured in the commit message as the reasoning for future-us.

## Checks

- All string keys are strings (\`tracksFile\`, \`patterns.*\`, \`cover.filename\`, \`disc.separator\`).
- \`libraryRoot\` is a string or \`undefined\`.
- \`artist.sortArticles\` is a boolean; \`artist.articles\` is a string array.
- \`flac.compressionLevel\` is an integer in \`0..8\`.
- \`disc.separator\` is non-empty and doesn't contain \`/\`.

Behavior for valid configs (including the default) is unchanged.

## API surface added

\`ConfigError\` class + \`validateConfig(cfg)\` assertion function, both re-exported from the config barrel in case anyone wants to check a config themselves.

## Test plan

- [x] \`pnpm run vitest\` — 354 passing (+14: per-key validator success + failure cases, plus a load-config throw-through test)
- [x] Full \`pnpm precommit\` chain green

## Changeset

Patch bump — user-visible for anyone whose config has silent bugs; no breaking API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)