### PR TITLE
fix(prompt): reject noOfDiscs < discNumber; drop dead DEFINITE_ARTICLES

### DIFF
--- a/.changeset/prompt-cross-validate-and-constants-cleanup.md
+++ b/.changeset/prompt-cross-validate-and-constants-cleanup.md
@@ -1,0 +1,11 @@
+---
+"@hansogj/music-utils": patch
+---
+
+fix: reject nonsensical `noOfDiscs < discNumber` in the disc-info prompt
+
+`music-utils-rip` (and any command that goes through `userDefinedPrompt`) now rejects a total-discs value smaller than the disc being ripped. Previously the prompt happily accepted "disc 2 of 1", which then produced a broken folder suffix like `(Disc 2∕1)` and downstream tag issues.
+
+Blank inputs (meaning "keep original") skip the check and fall back to the release's existing values, so you can leave either field alone without a spurious error.
+
+Also drops the dead `DEFINITE_ARTICLES` export from `constants.ts` (moved into `config.artist.articles` a while ago; still inlined into `BLACK_LIST_SIMILAR_WORD` for the similarity engine, which is intentionally decoupled from the sort-order transform).

--- a/packages/music-utils/src/constants.ts
+++ b/packages/music-utils/src/constants.ts
@@ -3,8 +3,17 @@ export const DISC_NO_SPLIT = '∕'; //  '::';
 export const TRACKS_FILE_NAME = 'tracks.txt';
 export const COVER_FILE_NAME = 'cover.jpg';
 export const DISC_LABEL = 'Disc';
-export const DEFINITE_ARTICLES = ['the', 'los', 'il', 'la', 'el', 'le'];
-export const BLACK_LIST_SIMILAR_WORD = DEFINITE_ARTICLES.concat([
+// Words stripped before fuzzy-matching artist names in `music-utils-similarities`.
+// Historically shared its head with `config.artist.articles` (the sort-order transform),
+// but the two are intentionally decoupled: a user can override the sort list without
+// changing what the similarity engine ignores.
+export const BLACK_LIST_SIMILAR_WORD = [
+  'the',
+  'los',
+  'il',
+  'la',
+  'el',
+  'le',
   '&',
   'a',
   'and',
@@ -22,4 +31,4 @@ export const BLACK_LIST_SIMILAR_WORD = DEFINITE_ARTICLES.concat([
   'quintet',
   'the band',
   'to',
-]);
+];

--- a/packages/music-utils/src/utils/prompt.test.ts
+++ b/packages/music-utils/src/utils/prompt.test.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 
 import { Release } from '../types';
-import { albumPrompt, Question, userDefinedPrompt, validate } from './prompt';
+import { albumPrompt, Question, userDefinedPrompt, validate, validateCrossField } from './prompt';
 
 const { mockPrompt } = vi.hoisted(() => ({ mockPrompt: vi.fn() }));
 vi.mock('prompts', () => ({
@@ -89,5 +89,34 @@ describe('prompt', () => {
     [{ name: 'aux', value: '1' }, true],
   ] as Array<[{ name: Question; value: string }, boolean]>)('with user input %p', (response, expected) => {
     it(`should validate into ${expected}`, () => expect(validate(response.name, response.value)).toEqual(expected));
+  });
+
+  describe('validateCrossField (noOfDiscs >= discNumber)', () => {
+    it('accepts when total equals current disc', () => {
+      expect(validateCrossField('noOfDiscs', '2', { discNumber: '2' }, {})).toBe(true);
+    });
+
+    it('accepts when total exceeds current disc', () => {
+      expect(validateCrossField('noOfDiscs', '3', { discNumber: '1' }, {})).toBe(true);
+    });
+
+    it('rejects when total < current disc typed in the same session', () => {
+      expect(validateCrossField('noOfDiscs', '1', { discNumber: '2' }, {})).toMatch(/must be ≥/);
+    });
+
+    it('falls back to original release.discNumber when discNumber is left blank', () => {
+      expect(validateCrossField('noOfDiscs', '1', { discNumber: '' }, { discNumber: '2' })).toMatch(
+        /must be ≥ current disc number \(2\)/,
+      );
+    });
+
+    it('skips the check when noOfDiscs value is blank (means: keep original)', () => {
+      expect(validateCrossField('noOfDiscs', '', { discNumber: '5' }, {})).toBe(true);
+    });
+
+    it('is a no-op for non-noOfDiscs fields', () => {
+      expect(validateCrossField('discNumber', '2', {}, {})).toBe(true);
+      expect(validateCrossField('year', '1971', {}, {})).toBe(true);
+    });
   });
 });

--- a/packages/music-utils/src/utils/prompt.ts
+++ b/packages/music-utils/src/utils/prompt.ts
@@ -28,6 +28,31 @@ export const validate = (name: Question, value: string) => {
   return true;
 };
 
+/**
+ * Cross-field check for the disc-info prompt: `noOfDiscs` (total) must be ≥ `discNumber`
+ * (the disc currently being ripped/tagged). Blank inputs are treated as "keep original"
+ * and fall back to the pre-prompt release values.
+ */
+export const validateCrossField = (
+  name: Question,
+  value: string,
+  currentAnswers: Record<string, unknown> | undefined,
+  original: Partial<Release>,
+): true | string => {
+  if (name !== 'noOfDiscs' || value === '') return true;
+
+  const answerDisc = currentAnswers?.discNumber != null ? `${currentAnswers.discNumber}`.trim() : '';
+  const rawDisc = answerDisc || original.discNumber || '';
+  const disc = parseInt(rawDisc, 10);
+  const total = parseInt(value, 10);
+
+  if (Number.isFinite(disc) && Number.isFinite(total) && total < disc) {
+    return `Total discs (${total}) must be ≥ current disc number (${disc})`;
+  }
+
+  return true;
+};
+
 const verifyPrompt = async (release: Partial<Release>): Promise<Partial<Release>> => {
   json(release);
 
@@ -62,7 +87,11 @@ export const userDefinedPrompt = async (release: Partial<Release>): Promise<Part
       name,
       message: `${name.toUpperCase()}: ${originalValue}`,
       type: 'text',
-      validate: (value: string) => validate(name as Question, value),
+      validate: (value: string, answers: Record<string, unknown>) => {
+        const single = validate(name as Question, value);
+        if (single !== true) return single;
+        return validateCrossField(name as Question, value, answers, release);
+      },
     })),
   );
 


### PR DESCRIPTION
## Summary

Bundles two small backlog items — they touch adjacent surfaces (\`prompt.ts\` and \`constants.ts\`) and are both low-risk.

## 1. Cross-field validation in the disc-info prompt

\`userDefinedPrompt\` now rejects a \`noOfDiscs\` value smaller than \`discNumber\`. Previously the prompt happily accepted "disc 2 of 1", which produced a broken folder suffix \`(Disc 2∕1)\` and downstream tag confusion.

- New exported helper: \`validateCrossField(name, value, currentAnswers, originalRelease)\`.
- Blank inputs (meaning "keep original") fall back to the release's existing values, so leaving either field alone works normally.
- Wired into the \`prompts\` library's \`validate(value, answers)\` callback so the user gets re-prompted for that specific field on mismatch, not a mid-tag crash.

**Example rejection message:** \`Total discs (1) must be ≥ current disc number (2)\`

## 2. Drop dead \`DEFINITE_ARTICLES\` export

It was moved into \`config.artist.articles\` in PR #72 but the export was left behind. Grep confirmed nothing outside \`constants.ts\` imports it — only \`BLACK_LIST_SIMILAR_WORD\` was concatenating it in-file.

Inlined the article words directly into \`BLACK_LIST_SIMILAR_WORD\` (the similarity engine's ignore-list is intentionally decoupled from the config's sort-order transform — a user can override one without changing the other).

## Test plan

- [x] \`pnpm run vitest\` — 360 passing (+6 new for \`validateCrossField\`)
- [x] Full \`pnpm precommit\` chain green

## Changeset

Patch bump — user-visible fix (fewer bad rips) plus dead-code removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)